### PR TITLE
feat: add STAC collections listing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ uvicorn main:app --reload
 The interactive page lets you call `/parse` and `/assemble` directly from the
 browser to verify your API.
 
+ ### List STAC collections
+
+Use the ``list-stac-collections`` subcommand to list collection IDs exposed by a
+STAC API:
+
+```bash
+parseo list-stac-collections --stac-url https://catalogue.dataspace.copernicus.eu/stac
+```
+
+Each collection ID is printed on its own line.
+
 ### Sample filenames from a STAC collection
 
 The ``stac-sample`` subcommand prints a few asset filenames from a STAC

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -7,7 +7,7 @@ import sys
 from typing import Any, Dict, List
 
 from parseo.parser import parse_auto, describe_schema, list_schemas  # parser helpers
-from parseo.stac_dataspace import sample_collection_filenames
+from parseo.stac_dataspace import list_collections, sample_collection_filenames
 
 
 # ---------- small utilities ----------
@@ -43,6 +43,17 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--samples", type=int, default=5, help="Number of filenames to list"
     )
     p_stac.add_argument(
+        "--stac-url",
+        required=True,
+        help="Base URL of the STAC API",
+    )
+
+    # list-stac-collections
+    p_stac_list = sp.add_parser(
+        "list-stac-collections",
+        help="List collection IDs available in a STAC API",
+    )
+    p_stac_list.add_argument(
         "--stac-url",
         required=True,
         help="Base URL of the STAC API",
@@ -177,6 +188,11 @@ def main(argv: List[str] | None = None) -> int:
             raise SystemExit(f"Failed to load CLMS catalog scraper: {exc}")
         for name in fetch_clms_products():
             print(name)
+        return 0
+
+    if args.cmd == "list-stac-collections":
+        for cid in list_collections(base_url=args.stac_url):
+            print(cid)
         return 0
 
     if args.cmd == "stac-sample":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,3 +154,23 @@ def test_cli_stac_sample_requires_url(capsys):
         cli.main(["stac-sample", "COL"])
     err = capsys.readouterr().err
     assert "--stac-url" in err
+
+
+def test_cli_list_stac_collections(monkeypatch, capsys):
+    called = {}
+
+    def fake_list_collections(*, base_url):
+        called["base_url"] = base_url
+        return ["A", "B"]
+
+    monkeypatch.setattr(cli, "list_collections", fake_list_collections)
+    sys.argv = [
+        "parseo",
+        "list-stac-collections",
+        "--stac-url",
+        "http://example",
+    ]
+    assert cli.main() == 0
+    out = capsys.readouterr().out.splitlines()
+    assert out == ["A", "B"]
+    assert called == {"base_url": "http://example"}


### PR DESCRIPTION
## Summary
- add `list-stac-collections` CLI command to display STAC API collection IDs
- document `list-stac-collections` usage in README
- cover new command with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab22d177448327bd81b98731051e9c