### PR TITLE
feat: add deep collection discovery

### DIFF
--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -58,6 +58,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         required=True,
         help="Base URL of the STAC API",
     )
+    p_stac_list.add_argument(
+        "--deep",
+        action="store_true",
+        help="Recursively follow child catalogs to list nested collections",
+    )
 
     # assemble
     p_asm = sp.add_parser(
@@ -191,7 +196,7 @@ def main(argv: List[str] | None = None) -> int:
         return 0
 
     if args.cmd == "list-stac-collections":
-        for cid in list_collections(base_url=args.stac_url):
+        for cid in list_collections(base_url=args.stac_url, deep=args.deep):
             print(cid)
         return 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,8 +159,9 @@ def test_cli_stac_sample_requires_url(capsys):
 def test_cli_list_stac_collections(monkeypatch, capsys):
     called = {}
 
-    def fake_list_collections(*, base_url):
+    def fake_list_collections(*, base_url, deep=False):
         called["base_url"] = base_url
+        called["deep"] = deep
         return ["A", "B"]
 
     monkeypatch.setattr(cli, "list_collections", fake_list_collections)
@@ -173,4 +174,26 @@ def test_cli_list_stac_collections(monkeypatch, capsys):
     assert cli.main() == 0
     out = capsys.readouterr().out.splitlines()
     assert out == ["A", "B"]
-    assert called == {"base_url": "http://example"}
+    assert called == {"base_url": "http://example", "deep": False}
+
+
+def test_cli_list_stac_collections_deep(monkeypatch, capsys):
+    called = {}
+
+    def fake_list_collections(*, base_url, deep=False):
+        called["base_url"] = base_url
+        called["deep"] = deep
+        return ["X"]
+
+    monkeypatch.setattr(cli, "list_collections", fake_list_collections)
+    sys.argv = [
+        "parseo",
+        "list-stac-collections",
+        "--stac-url",
+        "http://example",
+        "--deep",
+    ]
+    assert cli.main() == 0
+    out = capsys.readouterr().out.splitlines()
+    assert out == ["X"]
+    assert called == {"base_url": "http://example", "deep": True}


### PR DESCRIPTION
## Summary
- Allow STAC collection listing to recurse into child catalogs when `--deep` flag is provided
- Add `--deep` option to CLI `list-stac-collections` command
- Test deep listing in API and CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2ffdf41c832787ace9e3ec4fd60c