### PR TITLE
Prefer asset titles for STAC filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,19 @@ collection. The STAC API root must always be provided via ``--stac-url``
 parseo stac-sample SENTINEL-2 --samples 3 --stac-url https://catalogue.dataspace.copernicus.eu/stac
 ```
 
+Which might output:
+
+```
+SENTINEL-2:
+  S2A_MSIL1C_20210101T101031_N0209_R122_T33UUU_20210101T121023.SAFE
+  S2B_MSIL1C_20210101T101031_N0209_R122_T33UUU_20210101T121023.SAFE
+  S2A_MSIL1C_20210102T101031_N0209_R122_T33UUU_20210102T121023.SAFE
+```
+
+Asset filenames are taken from each asset's ``title`` when available; if not,
+the filename is parsed from the ``href``.  OData-style links such as
+``Products('NAME')/$value`` are handled automatically.
+
 Known collection aliases are automatically mapped to their official STAC IDs:
 
 | Alias | STAC ID |

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -98,6 +98,45 @@ def test_iter_asset_filenames_resolves_templates(monkeypatch):
     assert out == ["F.tif", "plain.tif"]
 
 
+def test_iter_asset_filenames_uses_title(monkeypatch):
+    def fake_read_json(url):
+        return {
+            "features": [
+                {
+                    "assets": {
+                        "a": {
+                            "title": "from-title.tif",
+                            "href": "http://files/Products('from-href')/$value",
+                        }
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(sd, "_read_json", fake_read_json)
+    out = list(sd.iter_asset_filenames("C1", base_url="http://y"))
+    assert out == ["from-title.tif"]
+
+
+def test_iter_asset_filenames_odata_href(monkeypatch):
+    def fake_read_json(url):
+        return {
+            "features": [
+                {
+                    "assets": {
+                        "a": {
+                            "href": "http://host/odata/v1/Products('NAME')/$value"
+                        }
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(sd, "_read_json", fake_read_json)
+    out = list(sd.iter_asset_filenames("C1", base_url="http://y"))
+    assert out == ["NAME"]
+
+
 def test_sample_collection_filenames_custom_base_url(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- derive STAC asset filenames from the asset title when available
- parse OData-style URLs and resolve templated hrefs for assets
- document STAC sampling output and behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab33b856dc8327b30bb74ce1d07d1c