### PR TITLE
Fix STAC asset name selection

### DIFF
--- a/src/parseo/stac_dataspace.py
+++ b/src/parseo/stac_dataspace.py
@@ -128,12 +128,15 @@ def iter_asset_filenames(
             assets = feat.get("assets", {})
             for asset in assets.values():
                 title = asset.get("title")
-                if title:
+                href = asset.get("href")
+                filename = None
+                # Many assets use a generic title like "Product" which does not
+                # convey the actual filename.  In such cases prefer extracting
+                # the name from the href.  Only fall back to the title if it is
+                # present and not the generic "Product".
+                if title and title.strip().lower() != "product":
                     filename = title
-                else:
-                    href = asset.get("href")
-                    if not href:
-                        continue
+                elif href:
                     if "$" in href:
                         href_sub = Template(href).safe_substitute(props)
                         if re.search(r"\$(?!value\b)\w+", href_sub):
@@ -144,6 +147,8 @@ def iter_asset_filenames(
                         filename = m.group(1)
                     else:
                         filename = href.rstrip("/").split("/")[-1]
+                else:
+                    continue
                 yield filename
                 remaining -= 1
                 if remaining == 0:

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -137,6 +137,28 @@ def test_iter_asset_filenames_odata_href(monkeypatch):
     assert out == ["NAME"]
 
 
+def test_iter_asset_filenames_generic_title_uses_href(monkeypatch):
+    """Assets with a generic title should fall back to the href."""
+
+    def fake_read_json(url):
+        return {
+            "features": [
+                {
+                    "assets": {
+                        "a": {
+                            "title": "Product",
+                            "href": "http://host/odata/v1/Products('NAME')/$value",
+                        }
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(sd, "_read_json", fake_read_json)
+    out = list(sd.iter_asset_filenames("C1", base_url="http://y"))
+    assert out == ["NAME"]
+
+
 def test_sample_collection_filenames_custom_base_url(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- ignore generic "Product" titles in STAC assets and use href to extract filenames
- add regression test for generic-title fallback

## Testing
- `PYTHONPATH=src pytest`
- `pre-commit run --files src/parseo/stac_dataspace.py tests/test_stac_dataspace.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68ab35cf590883278e9a3408272b916e