### PR TITLE
Handle query strings in STAC asset filenames

### DIFF
--- a/src/parseo/stac_dataspace.py
+++ b/src/parseo/stac_dataspace.py
@@ -7,7 +7,8 @@ functions require explicitly passing the ``base_url`` of the STAC service.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from urllib.parse import urljoin
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
 import urllib.error
 import urllib.request
 import json
@@ -146,7 +147,11 @@ def iter_asset_filenames(
                     if m:
                         filename = m.group(1)
                     else:
-                        filename = href.rstrip("/").split("/")[-1]
+                        parsed_url = urlparse(href)
+                        path = Path(parsed_url.path)
+                        filename = path.name
+                        if not path.suffix:
+                            filename += ".dat"
                 else:
                     continue
                 yield filename

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -137,6 +137,28 @@ def test_iter_asset_filenames_odata_href(monkeypatch):
     assert out == ["NAME"]
 
 
+def test_iter_asset_filenames_strips_query_and_fragment(monkeypatch):
+    def fake_read_json(url):
+        return {
+            "features": [
+                {
+                    "assets": {
+                        "a": {
+                            "href": "http://host/path/file.tif?token=1#frag"
+                        },
+                        "b": {
+                            "href": "http://host/path/file?token=1#frag"
+                        },
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(sd, "_read_json", fake_read_json)
+    out = list(sd.iter_asset_filenames("C1", base_url="http://y"))
+    assert out == ["file.tif", "file.dat"]
+
+
 def test_iter_asset_filenames_generic_title_uses_href(monkeypatch):
     """Assets with a generic title should fall back to the href."""
 


### PR DESCRIPTION
## Summary
- strip query strings and fragments from STAC asset hrefs
- ensure assets without extensions default to `.dat`
- test URL handling with query parameters and fragments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5d022c2483278e6613c0d0982016