### PR TITLE
Clarify STAC collection helpers

### DIFF
--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -7,7 +7,7 @@ import sys
 from typing import Any, Dict, List
 
 from parseo.parser import parse_auto, describe_schema, list_schemas  # parser helpers
-from parseo.stac_dataspace import list_collections, sample_collection_filenames
+from parseo.stac_dataspace import list_collections_http, sample_collection_filenames
 
 
 # ---------- small utilities ----------
@@ -196,7 +196,7 @@ def main(argv: List[str] | None = None) -> int:
         return 0
 
     if args.cmd == "list-stac-collections":
-        for cid in list_collections(base_url=args.stac_url, deep=args.deep):
+        for cid in list_collections_http(base_url=args.stac_url, deep=args.deep):
             print(cid)
         return 0
 

--- a/src/parseo/stac_dataspace.py
+++ b/src/parseo/stac_dataspace.py
@@ -1,4 +1,8 @@
-"""Helpers for querying STAC APIs.
+"""Helpers for querying STAC APIs via the standard library.
+
+The routines in this module intentionally rely only on :mod:`urllib` from the
+Python standard library to avoid pulling in heavier dependencies.  For a
+``pystac-client`` based alternative see :mod:`parseo.stac_scraper`.
 
 The Copernicus Data Space Ecosystem STAC root URL is available as
 ``CDSE_STAC_URL`` for convenience but is not used as a default.  All helper
@@ -40,11 +44,14 @@ def _read_json(url: str) -> dict:
         return json.load(resp)
 
 
-def list_collections(base_url: str, *, deep: bool = False) -> list[str]:
-    """Return available collection IDs from the STAC API.
+def list_collections_http(base_url: str, *, deep: bool = False) -> list[str]:
+    """Return available collection IDs from the STAC API using ``urllib``.
 
-    If ``deep`` is ``True`` the function follows ``rel='child'`` links and
-    gathers collection IDs from nested catalogs as well.
+    This lightweight helper performs raw HTTP requests without requiring
+    third-party libraries.  If ``deep`` is ``True`` the function follows
+    ``rel='child'`` links and gathers collection IDs from nested catalogs as
+    well.  For a variant powered by ``pystac-client`` see
+    :func:`parseo.stac_scraper.list_collections_client`.
     """
     base = _norm_base(base_url)
 
@@ -95,6 +102,10 @@ def list_collections(base_url: str, *, deep: bool = False) -> list[str]:
                     to_visit.append(urljoin(base_cur, href))
 
     return sorted(collections)
+
+
+# Backwards compatible alias until old name is fully deprecated
+list_collections = list_collections_http
 
 
 def iter_asset_filenames(

--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -1,0 +1,44 @@
+"""STAC helpers backed by ``pystac-client``.
+
+This module mirrors the utilities in :mod:`parseo.stac_dataspace` but relies on
+``pystac-client`` for STAC catalog traversal.  Use these helpers when the extra
+features of ``pystac-client`` are required.  For a lightweight alternative that
+only depends on the Python standard library see
+:mod:`parseo.stac_dataspace`.
+"""
+from __future__ import annotations
+
+def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
+    """Return collection IDs from a STAC API using ``pystac-client``.
+
+    Parameters mirror :func:`parseo.stac_dataspace.list_collections_http` but
+    this variant requires the optional ``pystac-client`` dependency.  It is
+    suitable when more advanced STAC handling is needed, at the cost of pulling
+    in the external library.
+    """
+    try:
+        from pystac_client import Client
+    except Exception as exc:  # pragma: no cover - exercised when dependency missing
+        raise SystemExit(
+            "pystac-client is required for list_collections_client"
+        ) from exc
+
+    client = Client.open(base_url)
+    collections = {c.id for c in client.get_collections()}
+    if not deep:
+        return sorted(collections)
+
+    # Breadth-first traversal of child catalogs.
+    to_visit = list(client.get_children())
+    visited: set[str] = set()
+    while to_visit:
+        child = to_visit.pop()
+        href = getattr(child, "href", None) or getattr(child, "target", None)
+        if not href or href in visited:
+            continue
+        visited.add(href)
+        sub_client = Client.open(href)
+        collections.update(c.id for c in sub_client.get_collections())
+        to_visit.extend(sub_client.get_children())
+
+    return sorted(collections)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,12 +159,12 @@ def test_cli_stac_sample_requires_url(capsys):
 def test_cli_list_stac_collections(monkeypatch, capsys):
     called = {}
 
-    def fake_list_collections(*, base_url, deep=False):
+    def fake_list_collections_http(*, base_url, deep=False):
         called["base_url"] = base_url
         called["deep"] = deep
         return ["A", "B"]
 
-    monkeypatch.setattr(cli, "list_collections", fake_list_collections)
+    monkeypatch.setattr(cli, "list_collections_http", fake_list_collections_http)
     sys.argv = [
         "parseo",
         "list-stac-collections",
@@ -180,12 +180,12 @@ def test_cli_list_stac_collections(monkeypatch, capsys):
 def test_cli_list_stac_collections_deep(monkeypatch, capsys):
     called = {}
 
-    def fake_list_collections(*, base_url, deep=False):
+    def fake_list_collections_http(*, base_url, deep=False):
         called["base_url"] = base_url
         called["deep"] = deep
         return ["X"]
 
-    monkeypatch.setattr(cli, "list_collections", fake_list_collections)
+    monkeypatch.setattr(cli, "list_collections_http", fake_list_collections_http)
     sys.argv = [
         "parseo",
         "list-stac-collections",

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -11,7 +11,7 @@ def test_list_collections_custom_base_url(monkeypatch):
         return {"collections": [{"id": "abc"}]}
 
     monkeypatch.setattr(sd, "_read_json", fake_read_json)
-    out = sd.list_collections(base_url="http://x")
+    out = sd.list_collections_http(base_url="http://x")
     assert urls == ["http://x/collections"]
     assert out == ["abc"]
 
@@ -38,7 +38,7 @@ def test_list_collections_deep(monkeypatch):
 
     monkeypatch.setattr(sd, "_read_json", fake_read_json)
 
-    out = sd.list_collections(base_url="http://x", deep=True)
+    out = sd.list_collections_http(base_url="http://x", deep=True)
     assert set(out) == {"top", "A", "B"}
     assert set(calls) == set(responses)
 
@@ -228,7 +228,7 @@ def test_sample_collection_filenames_nested(monkeypatch):
 
 def test_list_collections_requires_base_url():
     with pytest.raises(TypeError):
-        sd.list_collections()
+        sd.list_collections_http()
 
 
 def test_iter_asset_filenames_bad_collection(monkeypatch):


### PR DESCRIPTION
## Summary
- clarify stac_dataspace list_collections as lightweight urllib implementation
- add pystac-client based list_collections_client in new stac_scraper module
- update CLI and tests to use renamed list_collections_http helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab5d046e60832793f043ca2bd6aca9