### PR TITLE
docs: add STAC search and download example

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,34 @@ A different STAC service can be targeted by supplying its URL:
 parseo stac-sample my-collection --samples 2 --stac-url https://stac.example.com
 ```
 
+### Search STAC and download assets
+
+The ``parseo.stac_scraper`` module provides helpers for programmatic
+interaction with a STAC API.  The snippet below lists available collections
+and downloads the first asset matching a simple search:
+
+```python
+from parseo import stac_scraper
+
+stac_url = "https://catalogue.dataspace.copernicus.eu/stac"
+
+# List available collections
+for cid in stac_scraper.list_collections(stac_url):
+    print(cid)
+
+# Search the STAC and download the first matching asset
+stac_scraper.search_stac_and_download(
+    stac_url=stac_url,
+    collections=["SENTINEL-2"],
+    bbox=[13.0, 52.0, 13.5, 52.5],
+    datetime="2024-01-01/2024-01-02",
+    dest_dir="downloads",
+)
+```
+
+This functionality depends on the ``pystac-client`` and ``requests``
+packages being available at runtime.
+
 ---
 
 ## Command Line Interface


### PR DESCRIPTION
## Summary
- document `stac_scraper.search_stac_and_download` usage
- mention runtime dependencies `pystac-client` and `requests`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab5d04ead48327a5b2a39bc5e189c8