### PR TITLE
Handle STAC connection errors

### DIFF
--- a/src/parseo/stac_dataspace.py
+++ b/src/parseo/stac_dataspace.py
@@ -41,8 +41,11 @@ def _norm_base(base_url: str) -> str:
 
 
 def _read_json(url: str) -> dict:
-    with urllib.request.urlopen(url) as resp:  # type: ignore[call-arg]
-        return json.load(resp)
+    try:
+        with urllib.request.urlopen(url) as resp:  # type: ignore[call-arg]
+            return json.load(resp)
+    except urllib.error.URLError as err:
+        raise SystemExit(f"Could not connect to {url}: {err.reason}") from err
 
 
 def list_collections_http(base_url: str, *, deep: bool = False) -> list[str]:

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -265,3 +265,17 @@ def test_iter_asset_filenames_bad_collection(monkeypatch):
         == "Collection 'BAD' not found at http://u/. Use `parseo stac-sample <collection> --stac-url <url>` with a valid collection ID."
     )
 
+
+def test_sample_collection_filenames_url_error(monkeypatch):
+    """Connection issues should result in a clear error message."""
+
+    def fake_urlopen(url):
+        raise urllib.error.URLError("fail")
+
+    monkeypatch.setattr(sd.urllib.request, "urlopen", fake_urlopen)
+    with pytest.raises(SystemExit) as exc:
+        sd.sample_collection_filenames("C1", base_url="http://bad")
+    assert str(exc.value).startswith(
+        "Could not connect to http://bad/collections/C1"
+    )
+


### PR DESCRIPTION
## Summary
- gracefully handle network failures when reading STAC JSON
- test STAC sampling against unreachable hosts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab5ea2cf2c832783dbc761ecf4e9b1