### PR TITLE
Implement STAC search helper and tests

### DIFF
--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -8,6 +8,9 @@ only depends on the Python standard library see
 """
 from __future__ import annotations
 
+from pathlib import Path
+from urllib.parse import urlparse
+
 def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
     """Return collection IDs from a STAC API using ``pystac-client``.
 
@@ -42,3 +45,57 @@ def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
         to_visit.extend(sub_client.get_children())
 
     return sorted(collections)
+
+
+# Backwards compatible alias mirroring :mod:`parseo.stac_dataspace`
+list_collections = list_collections_client
+
+
+def search_stac_and_download(
+    *,
+    stac_url: str,
+    collections: list[str],
+    bbox: list[float] | tuple[float, float, float, float],
+    datetime: str,
+    dest_dir: str | Path,
+) -> Path:
+    """Download the first asset matching a STAC search.
+
+    The search is performed via :mod:`pystac-client` and the asset is retrieved
+    with :mod:`requests`. ``dest_dir`` is created if needed and the path to the
+    downloaded file is returned.
+    """
+
+    try:
+        from pystac_client import Client
+    except Exception as exc:  # pragma: no cover - exercised when dependency missing
+        raise SystemExit(
+            "pystac-client is required for search_stac_and_download"
+        ) from exc
+
+    try:
+        import requests
+    except Exception as exc:  # pragma: no cover - exercised when dependency missing
+        raise SystemExit("requests is required for search_stac_and_download") from exc
+
+    client = Client.open(stac_url)
+    search = client.search(collections=collections, bbox=bbox, datetime=datetime)
+    for item in search.get_items():
+        for asset in item.assets.values():
+            href = getattr(asset, "href", None)
+            if not href:
+                continue
+            name = getattr(asset, "title", None)
+            if not name:
+                name = Path(urlparse(href).path).name
+            dest_dir_path = Path(dest_dir)
+            dest_dir_path.mkdir(parents=True, exist_ok=True)
+            dest_path = dest_dir_path / name
+            with requests.get(href, stream=True) as resp:
+                resp.raise_for_status()
+                with open(dest_path, "wb") as fh:
+                    for chunk in resp.iter_content(chunk_size=8192):
+                        if chunk:
+                            fh.write(chunk)
+            return dest_path
+    raise SystemExit("No matching assets found")

--- a/tests/test_stac_scraper.py
+++ b/tests/test_stac_scraper.py
@@ -1,0 +1,97 @@
+import sys
+import types
+from pathlib import Path
+
+import parseo.stac_scraper as ss
+
+
+class FakeCollection:
+    def __init__(self, id):
+        self.id = id
+
+
+class FakeClient:
+    @staticmethod
+    def open(url):
+        assert url == "http://base"
+        return FakeClient()
+
+    def get_collections(self):
+        return [FakeCollection("A"), FakeCollection("B")]
+
+    def get_children(self):
+        return []
+
+
+class FakeAsset:
+    def __init__(self, href, title=None):
+        self.href = href
+        self.title = title
+
+
+class FakeItem:
+    def __init__(self):
+        self.assets = {"x": FakeAsset("http://example.com/file.bin", title="file.bin")}
+
+
+class FakeSearch:
+    def get_items(self):
+        yield FakeItem()
+
+
+class FakeClientSearch(FakeClient):
+    @staticmethod
+    def open(url):
+        assert url == "http://base"
+        return FakeClientSearch()
+
+    def search(self, **kwargs):
+        assert kwargs["collections"] == ["C"]
+        assert kwargs["bbox"] == [0, 0, 1, 1]
+        assert kwargs["datetime"] == "2024"
+        return FakeSearch()
+
+
+
+def test_list_collections_alias(monkeypatch):
+    fake_pc = types.SimpleNamespace(Client=FakeClient)
+    monkeypatch.setitem(sys.modules, "pystac_client", fake_pc)
+    out = ss.list_collections("http://base")
+    assert out == ["A", "B"]
+
+
+
+def test_search_stac_and_download(monkeypatch, tmp_path):
+    fake_pc = types.SimpleNamespace(Client=FakeClientSearch)
+    monkeypatch.setitem(sys.modules, "pystac_client", fake_pc)
+
+    class FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=8192):
+            yield b"data"
+
+    def fake_get(url, stream=True):
+        assert url == "http://example.com/file.bin"
+        return FakeResp()
+
+    fake_requests = types.SimpleNamespace(get=fake_get)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    dest = tmp_path / "dl"
+    path = ss.search_stac_and_download(
+        stac_url="http://base",
+        collections=["C"],
+        bbox=[0, 0, 1, 1],
+        datetime="2024",
+        dest_dir=dest,
+    )
+    assert path == dest / "file.bin"
+    assert path.read_bytes() == b"data"


### PR DESCRIPTION
## Summary
- expose `list_collections` alias in `stac_scraper`
- add `search_stac_and_download` utility for downloading first matching asset
- test STAC scraper collection listing and download workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5eec38988327b98d87fa59d33670