### PR TITLE
Skip unresolved $value assets from STAC filenames

### DIFF
--- a/src/parseo/stac_dataspace.py
+++ b/src/parseo/stac_dataspace.py
@@ -168,6 +168,8 @@ def iter_asset_filenames(
                             filename += ".dat"
                 else:
                     continue
+                if filename.startswith("$"):
+                    continue
                 yield filename
                 remaining -= 1
                 if remaining == 0:

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -181,6 +181,24 @@ def test_iter_asset_filenames_generic_title_uses_href(monkeypatch):
     assert out == ["NAME"]
 
 
+def test_iter_asset_filenames_skips_value_href(monkeypatch):
+    def fake_read_json(url):
+        return {
+            "features": [
+                {
+                    "assets": {
+                        "skip": {"href": "http://host/path/$value"},
+                        "keep": {"href": "http://host/path/file.tif"},
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(sd, "_read_json", fake_read_json)
+    out = list(sd.iter_asset_filenames("C1", base_url="http://y"))
+    assert out == ["file.tif"]
+
+
 def test_sample_collection_filenames_custom_base_url(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- ignore STAC assets whose resolved href still contains `$value`
- test that iter_asset_filenames omits `$value` assets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab639d2404832790b835a464ba3489