### PR TITLE
feat: filter STAC assets by role

### DIFF
--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -47,6 +47,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         required=True,
         help="Base URL of the STAC API",
     )
+    p_stac.add_argument(
+        "--asset-role",
+        help="Only include assets whose roles contain this value",
+    )
 
     # list-stac-collections
     p_stac_list = sp.add_parser(
@@ -202,7 +206,10 @@ def main(argv: List[str] | None = None) -> int:
 
     if args.cmd == "stac-sample":
         samples = sample_collection_filenames(
-            args.collection, args.samples, base_url=args.stac_url
+            args.collection,
+            args.samples,
+            base_url=args.stac_url,
+            asset_role=args.asset_role,
         )
         for cid in sorted(samples):
             print(f"{cid}:")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,10 +124,11 @@ def test_cli_schema_info(capsys):
 def test_cli_stac_sample_custom_url(monkeypatch, capsys):
     calls = {}
 
-    def fake_sample(collection, samples=5, *, base_url):
+    def fake_sample(collection, samples=5, *, base_url, asset_role=None):
         calls["collection"] = collection
         calls["samples"] = samples
         calls["base_url"] = base_url
+        calls["asset_role"] = asset_role
         return {"C1": ["a"], "C2": ["b"]}
 
     monkeypatch.setattr(cli, "sample_collection_filenames", fake_sample)
@@ -139,6 +140,8 @@ def test_cli_stac_sample_custom_url(monkeypatch, capsys):
         "2",
         "--stac-url",
         "http://example",
+        "--asset-role",
+        "data",
     ]
     assert cli.main() == 0
     out = capsys.readouterr().out.splitlines()
@@ -147,6 +150,7 @@ def test_cli_stac_sample_custom_url(monkeypatch, capsys):
         "collection": "COL",
         "samples": 2,
         "base_url": "http://example",
+        "asset_role": "data",
     }
 
 def test_cli_stac_sample_requires_url(capsys):

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -184,20 +184,24 @@ def test_iter_asset_filenames_generic_title_uses_href(monkeypatch):
 def test_sample_collection_filenames_custom_base_url(monkeypatch):
     called = {}
 
-    def fake_iter_tree(collection_id, *, base_url, limit):
+    def fake_iter_tree(collection_id, *, base_url, limit, asset_role=None):
         called["collection"] = collection_id
         called["base_url"] = base_url
         called["limit"] = limit
+        called["asset_role"] = asset_role
         yield (collection_id, "f1")
         yield (collection_id, "f2")
         yield (collection_id, "f3")
 
     monkeypatch.setattr(sd, "iter_collection_tree", fake_iter_tree)
-    res = sd.sample_collection_filenames("COL", 2, base_url="http://z")
+    res = sd.sample_collection_filenames(
+        "COL", 2, base_url="http://z", asset_role="data"
+    )
     assert called == {
         "collection": "COL",
         "base_url": "http://z",
         "limit": 2,
+        "asset_role": "data",
     }
     assert res == {"COL": ["f1", "f2"]}
 
@@ -205,8 +209,8 @@ def test_sample_collection_filenames_custom_base_url(monkeypatch):
 def test_sample_collection_filenames_alias(monkeypatch):
     calls = []
 
-    def fake_iter_tree(collection_id, *, base_url, limit):
-        calls.append(collection_id)
+    def fake_iter_tree(collection_id, *, base_url, limit, asset_role=None):
+        calls.append((collection_id, asset_role))
         yield (collection_id, "a")
         yield (collection_id, "b")
 
@@ -218,7 +222,7 @@ def test_sample_collection_filenames_alias(monkeypatch):
         "sentinel-2-l2a", base_url="http://z"
     )
     assert alias_res == official_res == {"sentinel-2-l2a": ["a", "b"]}
-    assert calls == ["sentinel-2-l2a", "sentinel-2-l2a"]
+    assert calls == [("sentinel-2-l2a", None), ("sentinel-2-l2a", None)]
 
 
 def test_sample_collection_filenames_nested(monkeypatch):
@@ -243,9 +247,44 @@ def test_sample_collection_filenames_nested(monkeypatch):
             "C3": ["c1", "c2"],
         }[collection_id])
 
-    monkeypatch.setattr(sd, "iter_asset_filenames", fake_iter_asset)
+    def fake_iter_asset_role(collection_id, *, base_url, limit=100, asset_role=None):
+        return fake_iter_asset(collection_id, base_url=base_url, limit=limit)
+
+    monkeypatch.setattr(sd, "iter_asset_filenames", fake_iter_asset_role)
     res = sd.sample_collection_filenames("ROOT", 1, base_url="http://x")
     assert res == {"C1": ["a1"], "C3": ["c1"]}
+
+
+def test_iter_asset_filenames_filters_role(monkeypatch):
+    def fake_read_json(url):
+        return {
+            "features": [
+                {
+                    "assets": {
+                        "a": {"href": "http://files/a.tif", "roles": ["data"]},
+                        "b": {"href": "http://files/b.tif", "roles": ["metadata"]},
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(sd, "_read_json", fake_read_json)
+    out = list(
+        sd.iter_asset_filenames("C1", base_url="http://y", asset_role="data")
+    )
+    assert out == ["a.tif"]
+
+
+def test_sample_collection_filenames_forwards_asset_role(monkeypatch):
+    called = {}
+
+    def fake_iter_tree(collection_id, *, base_url, limit, asset_role=None):
+        called["asset_role"] = asset_role
+        yield (collection_id, "f")
+
+    monkeypatch.setattr(sd, "iter_collection_tree", fake_iter_tree)
+    sd.sample_collection_filenames("COL", base_url="http://x", asset_role="data")
+    assert called["asset_role"] == "data"
 
 
 def test_list_collections_requires_base_url():


### PR DESCRIPTION
## Summary
- allow filtering STAC assets by role via new `asset_role` option
- expose `--asset-role` flag in `stac-sample` CLI command
- test asset role filtering for STAC helpers and CLI

## Testing
- `pytest`
- `pre-commit run --files src/parseo/stac_dataspace.py src/parseo/cli.py tests/test_cli.py tests/test_stac_dataspace.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab63b5b0b48327bf52c02f1c6817fd