### PR TITLE
Sanitize asset filenames

### DIFF
--- a/src/parseo/stac_dataspace.py
+++ b/src/parseo/stac_dataspace.py
@@ -123,7 +123,9 @@ def iter_asset_filenames(
 
     Pagination links (``rel="next"``) are followed until all pages are
     exhausted or ``limit`` filenames have been yielded.  When ``asset_role`` is
-    provided, only assets declaring that role are considered.
+    provided, only assets declaring that role are considered.  Resulting
+    filenames are sanitized: directory components are stripped and any
+    characters outside ``[A-Za-z0-9._-]`` are replaced with ``_``.
     """
     base = _norm_base(base_url)
     url = urljoin(base, f"collections/{collection_id}/items?limit={limit}")
@@ -174,6 +176,8 @@ def iter_asset_filenames(
                     continue
                 if filename.startswith("$"):
                     continue
+                filename = Path(filename).name
+                filename = re.sub(r"[^A-Za-z0-9._-]", "_", filename)
                 yield filename
                 remaining -= 1
                 if remaining == 0:

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -159,6 +159,24 @@ def test_iter_asset_filenames_strips_query_and_fragment(monkeypatch):
     assert out == ["file.tif", "file.dat"]
 
 
+def test_iter_asset_filenames_sanitizes(monkeypatch):
+    def fake_read_json(url):
+        return {
+            "features": [
+                {
+                    "assets": {
+                        "a": {"href": "http://host/path/../evil/fi*le.tif"},
+                        "b": {"title": "../weird?name"},
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(sd, "_read_json", fake_read_json)
+    out = list(sd.iter_asset_filenames("C1", base_url="http://y"))
+    assert out == ["fi_le.tif", "weird_name"]
+
+
 def test_iter_asset_filenames_generic_title_uses_href(monkeypatch):
     """Assets with a generic title should fall back to the href."""
 


### PR DESCRIPTION
## Summary
- sanitize returned asset filenames by removing path components and replacing unsafe characters
- document filename sanitization behavior
- add test for sanitation logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab665915e08327831d39be803d3743