### PR TITLE
feat: expand STAC ID aliases

### DIFF
--- a/src/parseo/stac_dataspace.py
+++ b/src/parseo/stac_dataspace.py
@@ -25,8 +25,13 @@ CDSE_STAC_URL = "https://catalogue.dataspace.copernicus.eu/stac/"
 
 # Mapping of common collection aliases to their official STAC IDs.
 # Keys are case-insensitive aliases as they might appear in user commands.
+# Accepted formats include variants such as "SENTINEL2_L1C",
+# "SENTINEL-2-L1C", or "S2_L2A".
 STAC_ID_ALIASES: dict[str, str] = {
     "SENTINEL2_L2A": "sentinel-2-l2a",
+    "S2_L2A": "sentinel-2-l2a",
+    "SENTINEL2_L1C": "sentinel-2-l1c",
+    "SENTINEL-2-L1C": "sentinel-2-l1c",
 }
 
 

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -3,6 +3,19 @@ import urllib.error
 import parseo.stac_dataspace as sd
 
 
+@pytest.mark.parametrize(
+    "alias, expected",
+    [
+        ("SENTINEL2_L2A", "sentinel-2-l2a"),
+        ("S2_L2A", "sentinel-2-l2a"),
+        ("SENTINEL2_L1C", "sentinel-2-l1c"),
+        ("SENTINEL-2-L1C", "sentinel-2-l1c"),
+    ],
+)
+def test_norm_collection_id_aliases(alias, expected):
+    assert sd._norm_collection_id(alias) == expected
+
+
 def test_list_collections_custom_base_url(monkeypatch):
     urls = []
 


### PR DESCRIPTION
## Summary
- broaden STAC alias mapping to cover Sentinel-2 L1C/L2A variations
- document alias naming conventions
- test collection ID normalization for new aliases

## Testing
- `pytest tests/test_stac_dataspace.py`
- `pre-commit run --files src/parseo/stac_dataspace.py tests/test_stac_dataspace.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab665a868083279c1516593a078f4e