### PR TITLE
Error on duplicate CLI fields

### DIFF
--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -100,6 +100,8 @@ def _kv_pairs_to_dict(pairs: List[str]) -> Dict[str, str]:
         v = v.strip()
         if not k:
             raise SystemExit(f"Invalid field '{p}': empty key.")
+        if k in out:
+            raise SystemExit(f"Duplicate field '{k}'.")
         out[k] = v
     return out
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,3 +201,25 @@ def test_cli_list_stac_collections_deep(monkeypatch, capsys):
     out = capsys.readouterr().out.splitlines()
     assert out == ["X"]
     assert called == {"base_url": "http://example", "deep": True}
+
+
+def test_kv_pairs_to_dict_duplicate_key():
+    with pytest.raises(SystemExit) as exc:
+        cli._kv_pairs_to_dict(["a=1", "a=2"])
+    assert "Duplicate field 'a'" in str(exc.value)
+
+
+def test_cli_assemble_duplicate_key(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "parseo",
+            "assemble",
+            "prefix=CLMS_WSI",
+            "prefix=OTHER",
+        ],
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "Duplicate field 'prefix'" in str(exc.value)


### PR DESCRIPTION
## Summary
- prevent duplicate key=value pairs in CLI by raising a clear error
- add tests for duplicate field handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab665e791c83278e6149cfd92596ca