### PR TITLE
Raise FileNotFoundError when STAC search yields no assets

### DIFF
--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -64,6 +64,12 @@ def search_stac_and_download(
     The search is performed via :mod:`pystac-client` and the asset is retrieved
     with :mod:`requests`. ``dest_dir`` is created if needed and the path to the
     downloaded file is returned.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the STAC search yields no downloadable assets or all downloads
+        fail.
     """
 
     try:
@@ -101,4 +107,4 @@ def search_stac_and_download(
                 return dest_path
             except requests.HTTPError:
                 continue
-    raise SystemExit("No matching assets found")
+    raise FileNotFoundError("No matching assets found")

--- a/tests/test_stac_scraper.py
+++ b/tests/test_stac_scraper.py
@@ -124,7 +124,7 @@ def test_search_stac_and_download_http_error(monkeypatch, tmp_path):
     fake_requests = types.SimpleNamespace(get=fake_get, HTTPError=HTTPError)
     monkeypatch.setitem(sys.modules, "requests", fake_requests)
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(FileNotFoundError):
         ss.search_stac_and_download(
             stac_url="http://base",
             collections=["C"],


### PR DESCRIPTION
## Summary
- raise `FileNotFoundError` instead of `SystemExit` when a STAC search doesn't return a usable asset
- document the new exception
- update tests to expect `FileNotFoundError`

## Testing
- `pytest tests/test_stac_scraper.py`
- `pre-commit run --files src/parseo/stac_scraper.py tests/test_stac_scraper.py` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6889b2e883279dad797367d650c7