### PR TITLE
Memoize schema loading and expose cache clear helper

### DIFF
--- a/src/parseo/__init__.py
+++ b/src/parseo/__init__.py
@@ -1,7 +1,7 @@
 from .parser import parse_auto
-from .assembler import assemble, assemble_auto
+from .assembler import assemble, assemble_auto, clear_schema_cache
 
-__all__ = ["parse_auto", "assemble", "assemble_auto"]
+__all__ = ["parse_auto", "assemble", "assemble_auto", "clear_schema_cache"]
 
 try:  # pragma: no cover - import failure handled for graceful degradation
     from . import parser  # noqa: F401  # import for side effect and re-export

--- a/src/parseo/assembler.py
+++ b/src/parseo/assembler.py
@@ -5,6 +5,7 @@ from importlib.resources import as_file, files
 from pathlib import Path
 import re
 from typing import Any, Dict
+from functools import lru_cache
 
 from ._json import load_json
 from .template import compile_template, _field_regex
@@ -13,8 +14,14 @@ from .template import compile_template, _field_regex
 SCHEMAS_ROOT = "schemas"
 
 
+@lru_cache(maxsize=None)
 def _load_schema(schema_path: str | Path) -> Dict[str, Any]:
-    return load_json(schema_path)
+    return load_json(str(schema_path))
+
+
+def clear_schema_cache() -> None:
+    """Clear the cached schemas."""
+    _load_schema.cache_clear()
 
 
 def _assemble_from_template(template: str, fields: Dict[str, Any]) -> str:
@@ -135,7 +142,7 @@ def _select_schema_by_first_compulsory(fields: Dict[str, Any]) -> Path:
 
     for p in _iter_schema_paths():
         try:
-            sch = load_json(p)
+            sch = _load_schema(p)
         except Exception:
             continue
 

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from parseo import assemble, assemble_auto
+from parseo import assemble, assemble_auto, clear_schema_cache
 
 
 def test_assemble_clms_fsc_schema():
@@ -161,3 +161,20 @@ def test_assemble_s2_invalid_generation_datetime():
     }
     with pytest.raises(ValueError):
         assemble(schema, fields)
+
+
+def test_clear_schema_cache(tmp_path):
+    clear_schema_cache()
+    schema = tmp_path / "schema.json"
+    schema.write_text('{"fields_order": ["a", "b"], "joiner": "_"}')
+    fields = {"a": "x", "b": "y"}
+
+    assert assemble(schema, fields) == "x_y"
+
+    schema.write_text('{"fields_order": ["a", "b"], "joiner": "-"}')
+
+    # Cached schema remains in effect
+    assert assemble(schema, fields) == "x_y"
+
+    clear_schema_cache()
+    assert assemble(schema, fields) == "x-y"


### PR DESCRIPTION
## Summary
- cache schema loading with `functools.lru_cache`
- add `clear_schema_cache` helper and export it
- update schema selection to use cached loader
- cover cache clearing with tests

## Testing
- `pytest`
- `pre-commit run --files src/parseo/assembler.py src/parseo/__init__.py tests/test_assembler.py` *(fails: command not found / installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2611f6e08327923a48e9a31c32f9