### PR TITLE
Handle missing template fields as ValueError

### DIFF
--- a/src/parseo/assembler.py
+++ b/src/parseo/assembler.py
@@ -92,7 +92,13 @@ def assemble(schema_path: str | Path, fields: Dict[str, Any]) -> str:
         if not sch.get("fields_order"):
             _, order = compile_template(template, sch.get("fields", {}))
             sch["fields_order"] = order
-        return _assemble_from_template(template, fields)
+        try:
+            return _assemble_from_template(template, fields)
+        except KeyError as exc:
+            name = exc.args[0]
+            raise ValueError(
+                f"Missing field '{name}' for schema {schema_path}"
+            ) from exc
 
     order = sch.get("fields_order")
     if not order or not isinstance(order, list):

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -25,6 +25,27 @@ def test_assemble_clms_fsc_schema():
     assert result == "CLMS_WSI_FSC_020m_T32TNS_20211018T103021_S2A_V100_FSCOG.tif"
 
 
+def test_assemble_missing_field_template_schema():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json"
+    )
+    fields = {
+        "prefix": "CLMS_WSI",
+        "product": "FSC",
+        "pixel_spacing": "020m",
+        "tile_id": "T32TNS",
+        "sensing_datetime": "20211018T103021",
+        # "platform" is intentionally omitted
+        "version": "V100",
+        "file_id": "FSCOG",
+        "extension": "tif",
+    }
+    msg = r"Missing field 'platform' for schema .*fsc_filename_v0_0_0\.json"
+    with pytest.raises(ValueError, match=msg):
+        assemble(schema, fields)
+
+
 def test_assemble_auto_wic_schema():
     fields = {
         "prefix": "CLMS_WSI",
@@ -39,6 +60,23 @@ def test_assemble_auto_wic_schema():
     }
     result = assemble_auto(fields)
     assert result == "CLMS_WSI_WIC_020m_T33WXP_20201024T103021_S2B_V100_WIC.tif"
+
+
+def test_assemble_auto_missing_field_template_schema():
+    fields = {
+        "prefix": "CLMS_WSI",
+        "product": "WIC",
+        "pixel_spacing": "020m",
+        "tile_id": "T33WXP",
+        "sensing_datetime": "20201024T103021",
+        # missing "platform"
+        "version": "V100",
+        "file_id": "WIC",
+        "extension": "tif",
+    }
+    msg = r"Missing field 'platform' for schema .*wic_s2_filename_v0_0_0\.json"
+    with pytest.raises(ValueError, match=msg):
+        assemble_auto(fields)
 
 def test_assemble_auto_modis_schema():
     fields = {


### PR DESCRIPTION
## Summary
- raise clear ValueError when mandatory field missing during template-based assembly
- add tests for missing field message in assemble and assemble_auto

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac26150fac832791649346e1682bca