### PR TITLE
Allow string for collections in STAC search

### DIFF
--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -54,7 +54,7 @@ list_collections = list_collections_client
 def search_stac_and_download(
     *,
     stac_url: str,
-    collections: list[str],
+    collections: str | list[str],
     bbox: list[float] | tuple[float, float, float, float],
     datetime: str,
     dest_dir: str | Path,
@@ -64,6 +64,9 @@ def search_stac_and_download(
     The search is performed via :mod:`pystac-client` and the asset is retrieved
     with :mod:`requests`. ``dest_dir`` is created if needed and the path to the
     downloaded file is returned.
+
+    ``collections`` may be a single string or a list of strings. A lone
+    string will be wrapped in a list before querying.
 
     Raises
     ------
@@ -83,6 +86,9 @@ def search_stac_and_download(
         import requests
     except Exception as exc:  # pragma: no cover - exercised when dependency missing
         raise SystemExit("requests is required for search_stac_and_download") from exc
+    if isinstance(collections, str):
+        collections = [collections]
+
 
     client = Client.open(stac_url)
     search = client.search(collections=collections, bbox=bbox, datetime=datetime)

--- a/tests/test_stac_scraper.py
+++ b/tests/test_stac_scraper.py
@@ -62,7 +62,8 @@ def test_list_collections_alias(monkeypatch):
 
 
 
-def test_search_stac_and_download(monkeypatch, tmp_path):
+@pytest.mark.parametrize("collections", [["C"], "C"])
+def test_search_stac_and_download(monkeypatch, tmp_path, collections):
     fake_pc = types.SimpleNamespace(Client=FakeClientSearch)
     monkeypatch.setitem(sys.modules, "pystac_client", fake_pc)
 
@@ -89,7 +90,7 @@ def test_search_stac_and_download(monkeypatch, tmp_path):
     dest = tmp_path / "dl"
     path = ss.search_stac_and_download(
         stac_url="http://base",
-        collections=["C"],
+        collections=collections,
         bbox=[0, 0, 1, 1],
         datetime="2024",
         dest_dir=dest,


### PR DESCRIPTION
## Summary
- allow passing a single collection ID string to `search_stac_and_download`
- test STAC search helper with list and string `collections`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac4e99e0f483278154979c12877a92