### PR TITLE
Normalize STAC URLs before pystac-client calls

### DIFF
--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.parse import urlparse
 
+from .stac_dataspace import _norm_base
+
 def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
     """Return collection IDs from a STAC API using ``pystac-client``.
 
@@ -26,7 +28,8 @@ def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
             "pystac-client is required for list_collections_client"
         ) from exc
 
-    client = Client.open(base_url)
+    base = _norm_base(base_url)
+    client = Client.open(base)
     collections = {c.id for c in client.get_collections()}
     if not deep:
         return sorted(collections)
@@ -90,6 +93,7 @@ def search_stac_and_download(
         collections = [collections]
 
 
+    stac_url = _norm_base(stac_url)
     client = Client.open(stac_url)
     search = client.search(collections=collections, bbox=bbox, datetime=datetime)
     for item in search.items():

--- a/tests/test_stac_scraper.py
+++ b/tests/test_stac_scraper.py
@@ -14,7 +14,7 @@ class FakeCollection:
 class FakeClient:
     @staticmethod
     def open(url):
-        assert url == "http://base"
+        assert url == "http://base/"
         return FakeClient()
 
     def get_collections(self):
@@ -43,7 +43,7 @@ class FakeSearch:
 class FakeClientSearch(FakeClient):
     @staticmethod
     def open(url):
-        assert url == "http://base"
+        assert url == "http://base/"
         return FakeClientSearch()
 
     def search(self, **kwargs):
@@ -54,16 +54,18 @@ class FakeClientSearch(FakeClient):
 
 
 
-def test_list_collections_alias(monkeypatch):
+@pytest.mark.parametrize("base_url", ["http://base", "http://base/"])
+def test_list_collections_alias(monkeypatch, base_url):
     fake_pc = types.SimpleNamespace(Client=FakeClient)
     monkeypatch.setitem(sys.modules, "pystac_client", fake_pc)
-    out = ss.list_collections("http://base")
+    out = ss.list_collections(base_url)
     assert out == ["A", "B"]
 
 
 
 @pytest.mark.parametrize("collections", [["C"], "C"])
-def test_search_stac_and_download(monkeypatch, tmp_path, collections):
+@pytest.mark.parametrize("stac_url", ["http://base", "http://base/"])
+def test_search_stac_and_download(monkeypatch, tmp_path, collections, stac_url):
     fake_pc = types.SimpleNamespace(Client=FakeClientSearch)
     monkeypatch.setitem(sys.modules, "pystac_client", fake_pc)
 
@@ -89,7 +91,7 @@ def test_search_stac_and_download(monkeypatch, tmp_path, collections):
 
     dest = tmp_path / "dl"
     path = ss.search_stac_and_download(
-        stac_url="http://base",
+        stac_url=stac_url,
         collections=collections,
         bbox=[0, 0, 1, 1],
         datetime="2024",


### PR DESCRIPTION
## Summary
- normalize base STAC URLs in `list_collections_client` and `search_stac_and_download`
- reuse `_norm_base` helper to ensure trailing slash before opening pystac client
- expand tests to verify trailing slash handling produces identical results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac5081fb288327a20042dd610244a1