### PR TITLE
Fix missing _norm_base in STAC scraper

### DIFF
--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.parse import urlparse
 
+from .stac_dataspace import _norm_base
+
 # Mapping of common collection aliases to their official STAC IDs.
 # Keys and values are uppercase so lookups can be performed on normalized
 # ``str.upper`` versions of user supplied IDs.

--- a/tests/test_stac_scraper.py
+++ b/tests/test_stac_scraper.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import pytest
 import parseo.stac_scraper as ss
 
+stac_url = "http://base"
+
 
 @pytest.mark.parametrize(
     "alias, expected",


### PR DESCRIPTION
## Summary
- Import `_norm_base` from the lightweight STAC helpers so the `stac_scraper` module can normalize base URLs
- Define a test STAC URL constant used in STAC scraper tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac584c4c04832782b894eb48560485