### PR TITLE
Handle temporal midpoint in STAC metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,13 +253,16 @@ for cid in stac_scraper.list_collections(stac_url):
         stac_url=stac_url,
         collections=[cid],
         bbox=[13.0, 52.0, 13.5, 52.5],
-        datetime="2024-01-01/2024-01-02",
+        datetime="2024-01-01T00:00:00Z/2024-01-02T00:00:00Z",
         dest_dir="downloads",
     )
 ```
 
 This functionality depends on the ``pystac-client`` and ``requests``
 packages being available at runtime.
+
+All temporal constraints should be expressed as timezone-aware ISO 8601
+strings (e.g., ``2024-01-01T00:00:00Z``).
 
 ### Scrape a STAC catalog
 


### PR DESCRIPTION
## Summary
- derive temporal midpoints with timezone-aware datetimes
- populate missing `datetime` from `start_datetime`/`end_datetime` metadata
- document timezone-aware STAC datetime usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca97878f88327af5e7c8fecc3d62b