### PR TITLE
Add CLMS HRL TCD schema and tests

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hrl/tcd/index.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tcd/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HRL-TCD",
+    "versions": [
+        {
+            "file": "tcd_filename_v1_0_0.json",
+            "version": "1.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/tcd/tcd_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tcd/tcd_filename_v1_0_0.json
@@ -1,0 +1,21 @@
+{
+  "schema_id": "copernicus:clms:hrl:tcd",
+  "schema_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS HRL Tree Cover Density product filename.",
+  "fields": {
+    "product_code": {"type": "string", "enum": ["TCD"], "description": "Product code"},
+    "reference_year": {"type": "string", "enum": ["2018"], "description": "Reference year"},
+    "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution"},
+    "aoi_code": {"type": "string", "pattern": "^[A-Z0-9]+$", "description": "Area of interest code"},
+    "epsg": {"type": "string", "pattern": "^EPSG\\d{4}$", "description": "Coordinate reference system"},
+    "version": {"type": "string", "pattern": "^\\d{3}$", "description": "Product version"},
+    "tile": {"type": "string", "pattern": "^[A-Z0-9]+$", "description": "Tile code"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "hrl_{product_code}_{reference_year}_{resolution}_{aoi_code}_{epsg}_v{version}_{tile}[.{extension}]",
+  "examples": [
+    "hrl_TCD_2018_010m_E042N18_EPSG3035_v100_E042N18.tif"
+  ]
+}

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -216,3 +216,36 @@ def test_clear_schema_cache(tmp_path):
 
     clear_schema_cache()
     assert assemble(schema, fields) == "x-y"
+
+def test_assemble_hrl_tcd_schema():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/hrl/tcd/tcd_filename_v1_0_0.json"
+    )
+    fields = {
+        "product_code": "TCD",
+        "reference_year": "2018",
+        "resolution": "010m",
+        "aoi_code": "E042N18",
+        "epsg": "EPSG3035",
+        "version": "100",
+        "tile": "E042N18",
+        "extension": "tif",
+    }
+    result = assemble(schema, fields)
+    assert result == "hrl_TCD_2018_010m_E042N18_EPSG3035_v100_E042N18.tif"
+
+
+def test_assemble_auto_hrl_tcd_schema():
+    fields = {
+        "product_code": "TCD",
+        "reference_year": "2018",
+        "resolution": "010m",
+        "aoi_code": "E042N18",
+        "epsg": "EPSG3035",
+        "version": "100",
+        "tile": "E042N18",
+        "extension": "tif",
+    }
+    result = assemble_auto(fields)
+    assert result == "hrl_TCD_2018_010m_E042N18_EPSG3035_v100_E042N18.tif"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -134,3 +134,16 @@ def test_hrvpp_st_variant():
     res = parse_auto(name)
     assert res.fields["tile_id"] == "W05S20-98765"
     assert res.fields["version"] == "V101"
+
+def test_hrl_tcd_example():
+    name = "hrl_TCD_2018_010m_E042N18_EPSG3035_v100_E042N18.tif"
+    res = parse_auto(name)
+    assert res is not None
+    assert res.fields["product_code"] == "TCD"
+    assert res.fields["reference_year"] == "2018"
+    assert res.fields["resolution"] == "010m"
+    assert res.fields["aoi_code"] == "E042N18"
+    assert res.fields["epsg"] == "EPSG3035"
+    assert res.fields["version"] == "100"
+    assert res.fields["tile"] == "E042N18"
+    assert res.fields["extension"] == "tif"


### PR DESCRIPTION
## Summary
- add Copernicus CLMS HRL Tree Cover Density filename schema
- test parsing and assembling of TCD filenames

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aca563e0f88327919dd0a45f1ebaa4