### PR TITLE
Add HRL Imperviousness schema and tests

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v1_0_0.json
@@ -1,0 +1,23 @@
+{
+  "schema_id": "copernicus:clms:hrl:imperviousness",
+  "schema_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS HRL Imperviousness Density product filename.",
+  "fields": {
+    "product_code": {"type": "string", "enum": ["IMD"], "description": "Product code"},
+    "reference_year": {"type": "string", "enum": ["2012", "2018", "2024"], "description": "Reference year"},
+    "resolution": {"type": "string", "enum": ["10m", "100m"], "description": "Spatial resolution"},
+    "aoi_code": {"type": "string", "enum": ["E40N20", "E60N10"], "description": "Area of interest code"},
+    "epsg": {"type": "string", "enum": ["EPSG3035"], "description": "Spatial reference system"},
+    "version": {"type": "string", "pattern": "^\\d{3}$", "description": "Product version"},
+    "tile": {"type": "string", "pattern": "^E\\d{2,3}N\\d{2,3}$", "description": "Tile identifier"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "hrl_{product_code}_{reference_year}_{resolution}_{aoi_code}_{epsg}_v{version}_{tile}[.{extension}]",
+    "examples": [
+      "hrl_IMD_2012_10m_E40N20_EPSG3035_v100_E40N20.tif",
+      "hrl_IMD_2018_100m_E60N10_EPSG3035_v101_E60N10.tif",
+      "hrl_IMD_2024_10m_E40N20_EPSG3035_v102_E40N20.tif"
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/imperviousness/index.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imperviousness/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HRL-Imperviousness",
+    "versions": [
+        {
+            "file": "imperviousness_filename_v1_0_0.json",
+            "version": "1.0.0",
+            "status": "current",
+        }
+    ]
+}

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -216,3 +216,18 @@ def test_clear_schema_cache(tmp_path):
 
     clear_schema_cache()
     assert assemble(schema, fields) == "x-y"
+
+@pytest.mark.parametrize("year", ["2012", "2018", "2024"])
+def test_assemble_auto_hrl_imperviousness_schema(year):
+    fields = {
+        "product_code": "IMD",
+        "reference_year": year,
+        "resolution": "10m",
+        "aoi_code": "E40N20",
+        "epsg": "EPSG3035",
+        "version": "100",
+        "tile": "E40N20",
+        "extension": "tif",
+    }
+    result = assemble_auto(fields)
+    assert result == f"hrl_IMD_{year}_10m_E40N20_EPSG3035_v100_E40N20.tif"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,5 @@
 from parseo.parser import parse_auto
+from parseo import assemble_auto
 import parseo.parser as parser
 import pytest
 from functools import lru_cache
@@ -134,3 +135,27 @@ def test_hrvpp_st_variant():
     res = parse_auto(name)
     assert res.fields["tile_id"] == "W05S20-98765"
     assert res.fields["version"] == "V101"
+
+def test_hrl_imperviousness_roundtrip_2012_10m():
+    name = "hrl_IMD_2012_10m_E40N20_EPSG3035_v100_E40N20.tif"
+    res = parse_auto(name)
+    assert res is not None
+    assert res.fields["reference_year"] == "2012"
+    assert res.fields["resolution"] == "10m"
+    assert assemble_auto(res.fields) == name
+
+
+def test_hrl_imperviousness_roundtrip_2018_100m():
+    name = "hrl_IMD_2018_100m_E60N10_EPSG3035_v101_E60N10.tif"
+    res = parse_auto(name)
+    assert res.fields["reference_year"] == "2018"
+    assert res.fields["resolution"] == "100m"
+    assert assemble_auto(res.fields) == name
+
+
+def test_hrl_imperviousness_roundtrip_2024_10m():
+    name = "hrl_IMD_2024_10m_E40N20_EPSG3035_v102_E40N20.tif"
+    res = parse_auto(name)
+    assert res.fields["reference_year"] == "2024"
+    assert res.fields["resolution"] == "10m"
+    assert assemble_auto(res.fields) == name


### PR DESCRIPTION
## Summary
- add HRL Imperviousness schema with filename template and example names
- cover Imperviousness filenames with parsing and assembling round-trip tests
- allow Imperviousness reference years 2012, 2018 and 2024

## Testing
- `pytest`
- `pre-commit run --files src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v1_0_0.json tests/test_parser.py tests/test_assembler.py` *(fails: pre-commit not installed, installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68aca56532548327b69f65709c796b0f