### PR TITLE
Add CLMS HRL NVLCC schema and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ Currently included schemas cover:
 - **NASA MODIS**: Terra/Aqua MODIS products
 - **EUMETSAT missions**: MTG, Metop
 - **Copernicus Land Monitoring Service (CLMS)**:
-  - Corine Land Cover (CLC)  
-  - High Resolution Water & Snow / Ice (HR-WSI)  
+  - Corine Land Cover (CLC)
+  - High Resolution Water & Snow / Ice (HR-WSI)
   - High Resolution Vegetation Phenology & Productivity (HR-VPP)
-  - High Resolution Layers: Grasslands  
+  - High Resolution Layers: Grasslands
+  - High Resolution Layers: Non-Vegetated Land Cover Change (HRL NVLCC)
 ---
 
 ## Installation
@@ -364,6 +365,12 @@ parseo assemble \
   prefix=CLMS_VPP product=FAPAR resolution=100m tile_id=T32TNS \
   start_date=20210101 end_date=20210110 version=V100 file_id=FAPAR extension=tif
 # -> CLMS_VPP_FAPAR_100m_T32TNS_20210101_20210110_V100_FAPAR.tif
+
+# Example: CLMS HRL NVLCC product (first field: prefix)
+parseo assemble \
+  prefix=CLMS_HRL product=NVLCC resolution=010m tile_id=T32TNS \
+  start_date=20210101 end_date=20211231 version=V100 file_id=NVLCC extension=tif
+# -> CLMS_HRL_NVLCC_010m_T32TNS_20210101_20211231_V100_NVLCC.tif
 ```
 
 ---

--- a/src/parseo/assembler.py
+++ b/src/parseo/assembler.py
@@ -165,6 +165,20 @@ def _select_schema_by_first_compulsory(fields: Dict[str, Any]) -> Path:
         if first_key not in fields:
             continue
 
+        # Validate that the provided value for the first compulsory field
+        # matches the schema's expectations (enum/pattern). This helps
+        # disambiguate schemas sharing the same first field name but with
+        # different allowed values.
+        specs = sch.get("fields", {})
+        spec = specs.get(first_key, {})
+        value = str(fields[first_key])
+        if "enum" in spec and value not in spec["enum"]:
+            continue
+        if "pattern" in spec:
+            pattern = _field_regex({"pattern": spec["pattern"]})
+            if not re.fullmatch(pattern, value):
+                continue
+
         overlap = sum(1 for k in fields.keys() if k in order)
         key = (overlap, len(order), str(p))
         if best is None or key > best:

--- a/src/parseo/schemas/copernicus/clms/hrlnvlcc/hrlnvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrlnvlcc/hrlnvlcc_filename_v0_0_0.json
@@ -1,0 +1,22 @@
+{
+  "schema_id": "copernicus:clms:hrlnvlcc",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS HRL Non-Vegetated Land Cover Change product filename.",
+  "fields": {
+    "prefix": {"type": "string", "enum": ["CLMS_HRL"], "description": "Constant prefix"},
+    "product": {"type": "string", "enum": ["NVLCC"], "description": "Product code"},
+    "resolution": {"type": "string", "enum": ["010m"], "description": "Spatial resolution"},
+    "tile_id": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "UTM tile identifier"},
+    "start_date": {"type": "string", "pattern": "^\\d{8}$", "description": "Start date (YYYYMMDD)"},
+    "end_date": {"type": "string", "pattern": "^\\d{8}$", "description": "End date (YYYYMMDD)"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "file_id": {"type": "string", "enum": ["NVLCC", "MTD"], "description": "File identifier"},
+    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+  },
+  "template": "{prefix}_{product}_{resolution}_{tile_id}_{start_date}_{end_date}_{version}_{file_id}[.{extension}]",
+  "examples": [
+    "CLMS_HRL_NVLCC_010m_T32TNS_20210101_20211231_V100_NVLCC.tif"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrlnvlcc/index.json
+++ b/src/parseo/schemas/copernicus/clms/hrlnvlcc/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HRL-NVLCC",
+    "versions": [
+        {
+            "file": "hrlnvlcc_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -129,6 +129,26 @@ def test_assemble_auto_fapar_schema():
     assert result == "CLMS_VPP_FAPAR_100m_T32TNS_20210101_20210110_V100_FAPAR.tif"
 
 
+def test_assemble_clms_hrlnvlcc_schema():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/hrlnvlcc/hrlnvlcc_filename_v0_0_0.json"
+    )
+    fields = {
+        "prefix": "CLMS_HRL",
+        "product": "NVLCC",
+        "resolution": "010m",
+        "tile_id": "T32TNS",
+        "start_date": "20210101",
+        "end_date": "20211231",
+        "version": "V100",
+        "file_id": "NVLCC",
+        "extension": "tif",
+    }
+    result = assemble(schema, fields)
+    assert result == "CLMS_HRL_NVLCC_010m_T32TNS_20210101_20211231_V100_NVLCC.tif"
+
+
 def test_assemble_clms_st_schema():
     schema = (
         Path(__file__).resolve().parents[1]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -134,3 +134,14 @@ def test_hrvpp_st_variant():
     res = parse_auto(name)
     assert res.fields["tile_id"] == "W05S20-98765"
     assert res.fields["version"] == "V101"
+
+
+def test_clms_hrlnvlcc_example():
+    name = "CLMS_HRL_NVLCC_010m_T32TNS_20210101_20211231_V100_NVLCC.tif"
+    res = parse_auto(name)
+    assert res is not None
+    assert res.fields["product"] == "NVLCC"
+    assert res.fields["tile_id"] == "T32TNS"
+    assert res.fields["start_date"] == "20210101"
+    assert res.fields["end_date"] == "20211231"
+    assert res.fields["version"] == "V100"


### PR DESCRIPTION
## Summary
- add unified schema for CLMS HRL Non-Vegetated Land Cover Change filenames
- fix schema auto-selection to validate the first field's value
- document HRL NVLCC usage and add parsing/assembling tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acab644f488327994e04778daa0332