### PR TITLE
Add CLCplus filename schema

### DIFF
--- a/src/parseo/schemas/copernicus/clms/clcplus/clcplus_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/clcplus_filename_v1_0_0.json
@@ -1,0 +1,20 @@
+{
+  "schema_id": "copernicus:clms:clcplus",
+  "schema_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLCplus product filename.",
+  "fields": {
+    "prefix": {"type": "string", "enum": ["CLCPLUS"], "description": "Dataset prefix"},
+    "variant": {"type": "string", "enum": ["BB"], "description": "Product variant"},
+    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
+    "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution"},
+    "tile_id": {"type": "string", "pattern": "^E\\d{2,3}N\\d{2,3}$", "description": "Tile identifier"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "{prefix}_{variant}_{reference_year}_{resolution}_{tile_id}_{version}[.{extension}]",
+  "examples": [
+    "CLCPLUS_BB_2023_010m_E40N20_V100.tif"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/clcplus/index.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "CLCPLUS",
+    "versions": [
+        {
+            "file": "clcplus_filename_v1_0_0.json",
+            "version": "1.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -169,3 +169,16 @@ def test_hrl_imperviousness_roundtrip_2024_10m():
     assert res.fields["reference_year"] == "2024"
     assert res.fields["resolution"] == "10m"
     assert assemble_auto(res.fields) == name
+
+def test_clcplus_example():
+    name = "CLCPLUS_BB_2023_010m_E40N20_V100.tif"
+    res = parse_auto(name)
+    assert res is not None
+    assert res.fields["prefix"] == "CLCPLUS"
+    assert res.fields["variant"] == "BB"
+    assert res.fields["reference_year"] == "2023"
+    assert res.fields["resolution"] == "010m"
+    assert res.fields["tile_id"] == "E40N20"
+    assert res.fields["version"] == "V100"
+    assert res.fields["extension"] == "tif"
+    assert assemble_auto(res.fields) == name


### PR DESCRIPTION
## Summary
- add filename schema for CLCplus dataset
- register CLCplus schema
- test round-trip parsing for CLCplus name

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acaf323168832782bee6e05efd69db