### PR TITLE
feat: unify HR-VPP VI schemas

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vi/index.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vi/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HR-VPP-VI",
+    "versions": [
+        {
+            "file": "vi_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vi/vi_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vi/vi_filename_v0_0_0.json
@@ -1,0 +1,22 @@
+{
+  "schema_id": "copernicus:clms:hr-vpp:vi",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS HR-VPP Vegetation Index product filename.",
+  "fields": {
+    "metric": {"type": "string", "enum": ["NDVI", "LAI"], "description": "Vegetation index metric"},
+    "composite_length": {"type": "string", "pattern": "^\\d{2}D$", "description": "Composite period length"},
+    "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution"},
+    "tile_id": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "UTM tile identifier"},
+    "sensing_date": {"type": "string", "pattern": "^\\d{8}$", "description": "Acquisition date (YYYYMMDD)"},
+    "platform": {"type": "string", "enum": ["S2"], "description": "Sensor platform"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "VPP_{metric}_{composite_length}_{resolution}_{tile_id}_{sensing_date}_{platform}_{version}[.{extension}]",
+  "examples": [
+    "VPP_NDVI_10D_010m_T32TNS_20240101_S2_V100.tif",
+    "VPP_LAI_10D_010m_T32TNS_20240101_S2_V100.tif"
+  ]
+}

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -129,6 +129,44 @@ def test_assemble_auto_fapar_schema():
     assert result == "CLMS_VPP_FAPAR_100m_T32TNS_20210101_20210110_V100_FAPAR.tif"
 
 
+def test_assemble_hrvpp_vi_ndvi_schema():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/hr-vpp/vi/vi_filename_v0_0_0.json"
+    )
+    fields = {
+        "metric": "NDVI",
+        "composite_length": "10D",
+        "resolution": "010m",
+        "tile_id": "T32TNS",
+        "sensing_date": "20240101",
+        "platform": "S2",
+        "version": "V100",
+        "extension": "tif",
+    }
+    result = assemble(schema, fields)
+    assert result == "VPP_NDVI_10D_010m_T32TNS_20240101_S2_V100.tif"
+
+
+def test_assemble_hrvpp_vi_lai_schema():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/hr-vpp/vi/vi_filename_v0_0_0.json"
+    )
+    fields = {
+        "metric": "LAI",
+        "composite_length": "10D",
+        "resolution": "010m",
+        "tile_id": "T32TNS",
+        "sensing_date": "20240101",
+        "platform": "S2",
+        "version": "V100",
+        "extension": "tif",
+    }
+    result = assemble(schema, fields)
+    assert result == "VPP_LAI_10D_010m_T32TNS_20240101_S2_V100.tif"
+
+
 def test_assemble_clms_st_schema():
     schema = (
         Path(__file__).resolve().parents[1]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -134,3 +134,31 @@ def test_hrvpp_st_variant():
     res = parse_auto(name)
     assert res.fields["tile_id"] == "W05S20-98765"
     assert res.fields["version"] == "V101"
+
+
+def test_hrvpp_vi_ndvi_example():
+    name = "VPP_NDVI_10D_010m_T32TNS_20240101_S2_V100.tif"
+    res = parse_auto(name)
+    assert res is not None
+    assert res.fields['metric'] == 'NDVI'
+    assert res.fields["composite_length"] == "10D"
+    assert res.fields["resolution"] == "010m"
+    assert res.fields["tile_id"] == "T32TNS"
+    assert res.fields["sensing_date"] == "20240101"
+    assert res.fields["platform"] == "S2"
+    assert res.fields["version"] == "V100"
+    assert res.fields["extension"] == "tif"
+
+
+def test_hrvpp_vi_lai_example():
+    name = "VPP_LAI_10D_010m_T32TNS_20240101_S2_V100.tif"
+    res = parse_auto(name)
+    assert res is not None
+    assert res.fields['metric'] == 'LAI'
+    assert res.fields["composite_length"] == "10D"
+    assert res.fields["resolution"] == "010m"
+    assert res.fields["tile_id"] == "T32TNS"
+    assert res.fields["sensing_date"] == "20240101"
+    assert res.fields["platform"] == "S2"
+    assert res.fields["version"] == "V100"
+    assert res.fields["extension"] == "tif"


### PR DESCRIPTION
## Summary
- consolidate HR-VPP NDVI and LAI into a generic Vegetation Index schema
- adjust tests to assemble and parse NDVI/LAI through the shared schema

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aca5671ba88327a7affd0aa49fb585