### PR TITLE
Add stac-download CLI command for STAC asset retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,18 @@ for cid in stac_scraper.list_collections(stac_url):
     )
 ```
 
+The same functionality is exposed via the ``stac-download`` CLI subcommand.
+
+```bash
+parseo stac-download --stac-url https://catalogue.dataspace.copernicus.eu/stac \
+  --collection SENTINEL-2-L2A --bbox 13.0 52.0 13.5 52.5 \
+  --datetime 2024-01-01T00:00:00Z/2024-01-02T00:00:00Z \
+  --dest-dir downloads
+```
+
+It prints the path of the downloaded asset and exits with a non-zero code if no
+matching asset is found.
+
 This functionality depends on the ``pystac-client`` and ``requests``
 packages being available at runtime.
 


### PR DESCRIPTION
## Summary
- add `stac-download` CLI subcommand to query a STAC API and download the first matching asset
- document new command in README

## Testing
- `python -m pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(failed: tests/test_assembler.py::test_assemble_clms_hrlvlcc_schema - ValueError: Field 'prefix' must be one of ['CLMS_HRLVLCC'], got 'CLMS_HRLVLC'; tests/test_assembler.py::test_assemble_auto_hrlvlcc_schema - ValueError: Could not select a schema. Include the schema's FIRST compulsory field among your inputs.)*

------
https://chatgpt.com/codex/tasks/task_e_68acc035c5d883278184b8bd173f1494