### PR TITLE
Use full HRL NVLCC prefix

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hrlnvlcc/hrlnvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrlnvlcc/hrlnvlcc_filename_v0_0_0.json
@@ -5,7 +5,7 @@
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HRL Non-Vegetated Land Cover Change product filename.",
   "fields": {
-    "prefix": {"type": "string", "enum": ["CLMS_HRL"], "description": "Constant prefix"},
+    "prefix": {"type": "string", "enum": ["CLMS_HRLNVLCC"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["NVLCC"], "description": "Product code"},
     "resolution": {"type": "string", "enum": ["010m"], "description": "Spatial resolution"},
     "tile_id": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "UTM tile identifier"},
@@ -17,6 +17,6 @@
   },
   "template": "{prefix}_{product}_{resolution}_{tile_id}_{start_date}_{end_date}_{version}_{file_id}[.{extension}]",
   "examples": [
-    "CLMS_HRL_NVLCC_010m_T32TNS_20210101_20211231_V100_NVLCC.tif"
+    "CLMS_HRLNVLCC_NVLCC_010m_T32TNS_20210101_20211231_V100_NVLCC.tif"
   ]
 }

--- a/src/parseo/schemas/copernicus/clms/hrlnvlcc/index.json
+++ b/src/parseo/schemas/copernicus/clms/hrlnvlcc/index.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "family": "HRL-NVLCC",
+    "family": "HRLNVLCC",
     "versions": [
         {
             "file": "hrlnvlcc_filename_v0_0_0.json",

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -250,6 +250,48 @@ def test_assemble_auto_hrlvlcc_schema():
     assert result == "CLMS_HRLVLC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
 
 
+def test_assemble_clms_hrlnvlcc_schema():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/hrlnvlcc/hrlnvlcc_filename_v0_0_0.json"
+    )
+    fields = {
+        "prefix": "CLMS_HRLNVLCC",
+        "product": "NVLCC",
+        "resolution": "010m",
+        "tile_id": "T32TNS",
+        "start_date": "20210101",
+        "end_date": "20211231",
+        "version": "V100",
+        "file_id": "NVLCC",
+        "extension": "tif",
+    }
+    result = assemble(schema, fields)
+    assert (
+        result
+        == "CLMS_HRLNVLCC_NVLCC_010m_T32TNS_20210101_20211231_V100_NVLCC.tif"
+    )
+
+
+def test_assemble_auto_hrlnvlcc_schema():
+    fields = {
+        "prefix": "CLMS_HRLNVLCC",
+        "product": "NVLCC",
+        "resolution": "010m",
+        "tile_id": "T32TNS",
+        "start_date": "20210101",
+        "end_date": "20211231",
+        "version": "V100",
+        "file_id": "NVLCC",
+        "extension": "tif",
+    }
+    result = assemble_auto(fields)
+    assert (
+        result
+        == "CLMS_HRLNVLCC_NVLCC_010m_T32TNS_20210101_20211231_V100_NVLCC.tif"
+    )
+
+
 def test_assemble_clms_n2k_schema():
     name = "n2k_2018_100m_E042N018_3035_v1_1.tif"
     schema = (


### PR DESCRIPTION
## Summary
- use full CLMS_HRLNVLCC prefix in schema
- sync HRL NVLCC index family name
- cover HRL NVLCC assembler with tests

## Testing
- `pytest tests/test_assembler.py::test_assemble_clms_hrlnvlcc_schema tests/test_assembler.py::test_assemble_auto_hrlnvlcc_schema -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc0d18cec8327a33cef308238409d