### PR TITLE
Add HR-WSI schema index and tests

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hr-wsi/index.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HR-WSI",
+    "versions": [
+        {
+            "file": "fsc_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
@@ -5,7 +5,7 @@
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HRL Vegetation & Land Cover Characteristics product filename.",
   "fields": {
-    "prefix": {"type": "string", "enum": ["CLMS_HRLVLCC"], "description": "Constant prefix"},
+    "prefix": {"type": "string", "enum": ["CLMS_HRLVLC"], "description": "Constant prefix"},
     "product": {
       "type": "string",
       "enum": ["IMD", "TCD", "FTY", "GRA", "SWF", "WAW"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,6 +99,7 @@ def test_list_schemas_exposes_known_families():
     fams = list_schemas()
     assert "S2" in fams
     assert "S1" in fams
+    assert "HR-WSI" in fams
 
 
 def test_cli_list_schemas_outputs_families(capsys):
@@ -106,6 +107,7 @@ def test_cli_list_schemas_outputs_families(capsys):
     out = capsys.readouterr().out.splitlines()
     assert "S1" in out
     assert "S2" in out
+    assert "HR-WSI" in out
     assert all("index.json" not in line for line in out)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,6 +35,13 @@ def test_s3_example():
     assert res.fields["platform"] == "S3A"
 
 
+def test_hr_wsi_example():
+    name = "CLMS_WSI_FSC_020m_T32TNS_20211018T103021_S2A_V100_FSCOG.tif"
+    res = parse_auto(name)
+    assert res.match_family == "HR-WSI"
+    assert res.fields["product"] == "FSC"
+
+
 def test_near_miss_reports_field():
     name = "S2X_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE"
     with pytest.raises(parser.ParseError) as exc:


### PR DESCRIPTION
## Summary
- register HR-WSI schemas with a new index.json
- exercise HR-WSI through parser and CLI tests
- correct HRLVLCC schema prefix enumeration

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acc0de7a988327b7af186204b4478e