### PR TITLE
feat: add provider to CLCPLUS prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,9 +371,9 @@ parseo assemble \
 
 # Example: CLMS HRLVLCC product (first field: prefix)
 parseo assemble \
-  prefix=CLMS_HRLVLC product=IMD resolution=010m tile_id=T32TNS \
+  prefix=CLMS_HRLVLCC product=IMD resolution=010m tile_id=T32TNS \
   sensing_datetime=20210101T000000 version=V100 file_id=IMD extension=tif
-# -> CLMS_HRLVLC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif
+# -> CLMS_HRLVLCC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif
 
 # Example: CLMS HRL NVLCC product (first field: prefix)
 parseo assemble \

--- a/src/parseo/schemas/copernicus/clms/clcplus/clcplus_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/clcplus_filename_v1_0_0.json
@@ -5,7 +5,7 @@
   "stac_extensions": ["raster", "eo"],
   "description": "CLCplus product filename.",
   "fields": {
-    "prefix": {"type": "string", "enum": ["CLCPLUS"], "description": "Dataset prefix"},
+    "prefix": {"type": "string", "enum": ["CLMS_CLCPLUS"], "description": "Dataset prefix"},
     "variant": {"type": "string", "enum": ["BB"], "description": "Product variant"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
     "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution"},
@@ -15,6 +15,6 @@
   },
   "template": "{prefix}_{variant}_{reference_year}_{resolution}_{tile_id}_{version}[.{extension}]",
   "examples": [
-    "CLCPLUS_BB_2023_010m_E40N20_V100.tif"
+    "CLMS_CLCPLUS_BB_2023_010m_E40N20_V100.tif"
   ]
 }

--- a/src/parseo/schemas/copernicus/clms/clcplus/index.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/index.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "family": "CLCPLUS",
+    "family": "CLMS_CLCPLUS",
     "versions": [
         {
             "file": "clcplus_filename_v1_0_0.json",

--- a/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
@@ -24,6 +24,6 @@
   },
   "template": "{prefix}_{product}_{resolution}_{tile_id}_{sensing_datetime}_{version}_{file_id}[.{extension}]",
   "examples": [
-    "CLMS_HRLVLC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
+    "CLMS_HRLVLCC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
   ]
 }

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -222,7 +222,7 @@ def test_assemble_clms_hrlvlcc_schema():
         / "src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json"
     )
     fields = {
-        "prefix": "CLMS_HRLVLC",
+        "prefix": "CLMS_HRLVLCC",
         "product": "IMD",
         "resolution": "010m",
         "tile_id": "T32TNS",
@@ -232,12 +232,12 @@ def test_assemble_clms_hrlvlcc_schema():
         "extension": "tif",
     }
     result = assemble(schema, fields)
-    assert result == "CLMS_HRLVLC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
+    assert result == "CLMS_HRLVLCC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
 
 
 def test_assemble_auto_hrlvlcc_schema():
     fields = {
-        "prefix": "CLMS_HRLVLC",
+        "prefix": "CLMS_HRLVLCC",
         "product": "IMD",
         "resolution": "010m",
         "tile_id": "T32TNS",
@@ -247,7 +247,39 @@ def test_assemble_auto_hrlvlcc_schema():
         "extension": "tif",
     }
     result = assemble_auto(fields)
-    assert result == "CLMS_HRLVLC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
+    assert result == "CLMS_HRLVLCC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
+
+
+def test_assemble_clms_clcplus_schema():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/clcplus/clcplus_filename_v1_0_0.json"
+    )
+    fields = {
+        "prefix": "CLMS_CLCPLUS",
+        "variant": "BB",
+        "reference_year": "2023",
+        "resolution": "010m",
+        "tile_id": "E40N20",
+        "version": "V100",
+        "extension": "tif",
+    }
+    result = assemble(schema, fields)
+    assert result == "CLMS_CLCPLUS_BB_2023_010m_E40N20_V100.tif"
+
+
+def test_assemble_auto_clms_clcplus_schema():
+    fields = {
+        "prefix": "CLMS_CLCPLUS",
+        "variant": "BB",
+        "reference_year": "2023",
+        "resolution": "010m",
+        "tile_id": "E40N20",
+        "version": "V100",
+        "extension": "tif",
+    }
+    result = assemble_auto(fields)
+    assert result == "CLMS_CLCPLUS_BB_2023_010m_E40N20_V100.tif"
 
 
 def test_assemble_clms_n2k_schema():


### PR DESCRIPTION
## Summary
- include CLMS provider in CLCPLUS prefix
- align CLCPLUS index family and add assembler tests
- correct HRLVLCC prefix in schema, docs, and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acc0d4d6008327aa760a3d9c60acca