### PR TITLE
fix: correct CLMS HRLVLCC example prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,9 +371,9 @@ parseo assemble \
 
 # Example: CLMS HRLVLCC product (first field: prefix)
 parseo assemble \
-  prefix=CLMS_HRLVLC product=IMD resolution=010m tile_id=T32TNS \
+  prefix=CLMS_HRLVLCC product=IMD resolution=010m tile_id=T32TNS \
   sensing_datetime=20210101T000000 version=V100 file_id=IMD extension=tif
-# -> CLMS_HRLVLC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif
+# -> CLMS_HRLVLCC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif
 
 # Example: CLMS HRL NVLCC product (first field: prefix)
 parseo assemble \

--- a/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
@@ -24,6 +24,6 @@
   },
   "template": "{prefix}_{product}_{resolution}_{tile_id}_{sensing_datetime}_{version}_{file_id}[.{extension}]",
   "examples": [
-    "CLMS_HRLVLC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
+    "CLMS_HRLVLCC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
   ]
 }

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -222,7 +222,7 @@ def test_assemble_clms_hrlvlcc_schema():
         / "src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json"
     )
     fields = {
-        "prefix": "CLMS_HRLVLC",
+        "prefix": "CLMS_HRLVLCC",
         "product": "IMD",
         "resolution": "010m",
         "tile_id": "T32TNS",
@@ -232,12 +232,12 @@ def test_assemble_clms_hrlvlcc_schema():
         "extension": "tif",
     }
     result = assemble(schema, fields)
-    assert result == "CLMS_HRLVLC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
+    assert result == "CLMS_HRLVLCC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
 
 
 def test_assemble_auto_hrlvlcc_schema():
     fields = {
-        "prefix": "CLMS_HRLVLC",
+        "prefix": "CLMS_HRLVLCC",
         "product": "IMD",
         "resolution": "010m",
         "tile_id": "T32TNS",
@@ -247,7 +247,7 @@ def test_assemble_auto_hrlvlcc_schema():
         "extension": "tif",
     }
     result = assemble_auto(fields)
-    assert result == "CLMS_HRLVLC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
+    assert result == "CLMS_HRLVLCC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
 
 
 def test_assemble_clms_n2k_schema():


### PR DESCRIPTION
## Summary
- align HRLVLCC schema example prefix with enum `CLMS_HRLVLCC`
- update assembler tests and documentation to use corrected prefix

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc0d714b88327bdb952d73fe879e9