### PR TITLE
Align CLMS HR-VPP ST prefix with provider naming

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st/index.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st/index.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "family": "HR-VPP-ST",
+    "family": "CLMS_VPP-ST",
     "versions": [
         {
             "file": "st_filename_v0_0_0.json",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st/st_filename_v0_0_0.json
@@ -5,7 +5,7 @@
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-VPP Seasonal Trajectories Plant Phenology Index product filename.",
   "fields": {
-    "prefix": {"type": "string", "enum": ["ST"], "description": "Constant prefix"},
+    "prefix": {"type": "string", "enum": ["CLMS_VPP"], "description": "Constant prefix"},
     "timestamp": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition timestamp (YYYYMMDDTHHMMSS)"},
     "sensor": {"type": "string", "enum": ["S2"], "description": "Sensor platform"},
     "tile_id": {"type": "string", "pattern": "^[EW]\\d{2}[NS]\\d{2}-\\d{5}$", "description": "Regional tile identifier"},
@@ -16,6 +16,6 @@
   },
   "template": "{prefix}_{timestamp}_{sensor}_{tile_id}_{resolution}_{version}_{product}[.{extension}]",
   "examples": [
-    "ST_20240101T123045_S2_E15N45-01234_010m_V100_PPI.tif"
+    "CLMS_VPP_20240101T123045_S2_E15N45-01234_010m_V100_PPI.tif"
   ]
 }

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -134,7 +134,7 @@ def test_assemble_clms_st_schema():
         / "src/parseo/schemas/copernicus/clms/hr-vpp/st/st_filename_v0_0_0.json"
     )
     fields = {
-        "prefix": "ST",
+        "prefix": "CLMS_VPP",
         "timestamp": "20240101T123045",
         "sensor": "S2",
         "tile_id": "E15N45-01234",
@@ -144,12 +144,12 @@ def test_assemble_clms_st_schema():
         "extension": "tif",
     }
     result = assemble(schema, fields)
-    assert result == "ST_20240101T123045_S2_E15N45-01234_010m_V100_PPI.tif"
+    assert result == "CLMS_VPP_20240101T123045_S2_E15N45-01234_010m_V100_PPI.tif"
 
 
 def test_assemble_auto_st_schema():
     fields = {
-        "prefix": "ST",
+        "prefix": "CLMS_VPP",
         "timestamp": "20231231T000000",
         "sensor": "S2",
         "tile_id": "W05S20-98765",
@@ -159,7 +159,7 @@ def test_assemble_auto_st_schema():
         "extension": "tif",
     }
     result = assemble_auto(fields)
-    assert result == "ST_20231231T000000_S2_W05S20-98765_030m_V101_PPI.tif"
+    assert result == "CLMS_VPP_20231231T000000_S2_W05S20-98765_030m_V101_PPI.tif"
 
 
 def test_assemble_s2_invalid_processing_baseline():
@@ -222,7 +222,7 @@ def test_assemble_clms_hrlvlcc_schema():
         / "src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json"
     )
     fields = {
-        "prefix": "CLMS_HRLVLC",
+        "prefix": "CLMS_HRLVLCC",
         "product": "IMD",
         "resolution": "010m",
         "tile_id": "T32TNS",
@@ -232,12 +232,12 @@ def test_assemble_clms_hrlvlcc_schema():
         "extension": "tif",
     }
     result = assemble(schema, fields)
-    assert result == "CLMS_HRLVLC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
+    assert result == "CLMS_HRLVLCC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
 
 
 def test_assemble_auto_hrlvlcc_schema():
     fields = {
-        "prefix": "CLMS_HRLVLC",
+        "prefix": "CLMS_HRLVLCC",
         "product": "IMD",
         "resolution": "010m",
         "tile_id": "T32TNS",
@@ -247,7 +247,7 @@ def test_assemble_auto_hrlvlcc_schema():
         "extension": "tif",
     }
     result = assemble_auto(fields)
-    assert result == "CLMS_HRLVLC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
+    assert result == "CLMS_HRLVLCC_IMD_010m_T32TNS_20210101T000000_V100_IMD.tif"
 
 
 def test_assemble_clms_n2k_schema():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -117,10 +117,10 @@ def test_modis_example():
 
 
 def test_hrvpp_st_example():
-    name = "ST_20240101T123045_S2_E15N45-01234_010m_V100_PPI.tif"
+    name = "CLMS_VPP_20240101T123045_S2_E15N45-01234_010m_V100_PPI.tif"
     res = parse_auto(name)
     assert res is not None
-    assert res.fields["prefix"] == "ST"
+    assert res.fields["prefix"] == "CLMS_VPP"
     assert res.fields["timestamp"] == "20240101T123045"
     assert res.fields["sensor"] == "S2"
     assert res.fields["tile_id"] == "E15N45-01234"
@@ -130,7 +130,7 @@ def test_hrvpp_st_example():
     assert res.fields["extension"] == "tif"
 
 def test_hrvpp_st_variant():
-    name = "ST_20231231T000000_S2_W05S20-98765_030m_V101_PPI.tif"
+    name = "CLMS_VPP_20231231T000000_S2_W05S20-98765_030m_V101_PPI.tif"
     res = parse_auto(name)
     assert res.fields["tile_id"] == "W05S20-98765"
     assert res.fields["version"] == "V101"


### PR DESCRIPTION
## Summary
- use CLMS_VPP prefix for HR-VPP Seasonal Trajectories schema
- update HR-VPP ST index family and tests for new prefix
- fix HRLVLCC tests to match schema prefix

## Testing
- `pre-commit run --files src/parseo/schemas/copernicus/clms/hr-vpp/st/st_filename_v0_0_0.json src/parseo/schemas/copernicus/clms/hr-vpp/st/index.json tests/test_parser.py tests/test_assembler.py` *(command failed: bash: command not found: pre-commit)*
- `pip install pre-commit` *(failed: Tunnel connection failed: 403 Forbidden)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acc0ce96108327887d8219bf31b48a