### PR TITLE
feat: add CZ product schema

### DIFF
--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -24,7 +24,7 @@ class ParseResult:
     match_family: Optional[str] = None  # e.g., "S1", "S2", "LANDSAT"
 
 
-@dataclass(frozen=True)
+@dataclass
 class ParseError(Exception):
     """Raised when a filename nearly matches a schema but fails on a field."""
 
@@ -326,11 +326,13 @@ def parse_auto(name: str) -> ParseResult:
 
     # Quick family hint based on discovered tokens
     product_hint = None
+    best_len = 0
     u = name.upper()
     for fam, meta in info.items():
-        if any(u.startswith(tok) for tok in meta.tokens):
-            product_hint = fam
-            break
+        for tok in meta.tokens:
+            if u.startswith(tok) and len(tok) > best_len:
+                product_hint = fam
+                best_len = len(tok)
 
     # Try hinted schema first (if any)
     hinted_meta = info.get(product_hint) if product_hint else None

--- a/src/parseo/schemas/copernicus/clms/hrl/hrl_imd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/hrl_imd_filename_v0_0_0.json
@@ -1,0 +1,22 @@
+{
+  "schema_id": "copernicus:clms:hrl:imd",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster"],
+  "description": "CLMS HRL Imperviousness Density product filename.",
+  "fields": {
+    "prefix": {"type": "string", "enum": ["hrl"], "description": "Constant prefix"},
+    "product": {"type": "string", "enum": ["IMD"], "description": "Product code"},
+    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
+    "resolution": {"type": "string", "pattern": "^\\d{2}m$", "description": "Spatial resolution"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{2}[NS]\\d{2}$", "description": "Grid tile identifier"},
+    "crs": {"type": "string", "pattern": "^EPSG\\d{4,5}$", "description": "Coordinate reference system"},
+    "version": {"type": "string", "pattern": "^v\\d{3}$", "description": "Product version"},
+    "tile_id_2": {"type": "string", "pattern": "^[EW]\\d{2}[NS]\\d{2}$", "description": "Repeated tile identifier"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "{prefix}_{product}_{reference_year}_{resolution}_{tile_id}_{crs}_{version}_{tile_id_2}[.{extension}]",
+  "examples": [
+    "hrl_IMD_2024_10m_E40N20_EPSG3035_v102_E40N20.tif"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/index.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HRL",
+    "versions": [
+        {
+            "file": "hrl_imd_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
@@ -5,7 +5,7 @@
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HRL Vegetation & Land Cover Characteristics product filename.",
   "fields": {
-    "prefix": {"type": "string", "enum": ["CLMS_HRLVLCC"], "description": "Constant prefix"},
+    "prefix": {"type": "string", "enum": ["CLMS_HRLVLC"], "description": "Constant prefix"},
     "product": {
       "type": "string",
       "enum": ["IMD", "TCD", "FTY", "GRA", "SWF", "WAW"],

--- a/src/parseo/schemas/copernicus/cz/cz_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/cz/cz_filename_v0_0_0.json
@@ -1,0 +1,52 @@
+{
+  "schema_id": "copernicus:cz",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "vector"
+  ],
+  "description": "Schema for CZ vector products.",
+  "fields": {
+    "prefix": {
+      "type": "string",
+      "enum": [
+        "CZ"
+      ],
+      "description": "Constant prefix"
+    },
+    "product": {
+      "type": "string",
+      "pattern": "^[A-Z0-9]+$",
+      "description": "Product code"
+    },
+    "tile_id": {
+      "type": "string",
+      "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+      "description": "UTM tile identifier"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{8}$",
+      "description": "Reference date (YYYYMMDD)"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "gpkg",
+        "zip",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{prefix}_{product}_{tile_id}_{date}_{version}[.{extension}]",
+  "examples": [
+    "CZ_FOO_T32TNS_20210101_V100.gpkg",
+    "CZ_BAR_T32TNS_20210202_V101.zip"
+  ]
+}

--- a/src/parseo/schemas/copernicus/cz/index.json
+++ b/src/parseo/schemas/copernicus/cz/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "CZ",
+    "versions": [
+        {
+            "file": "cz_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -205,7 +205,6 @@ def scrape_catalog(root: str | Path, *, limit: int = 100) -> list[dict[str, str]
             text = read_text(path)
         except Exception:
             return {}
-        out: dict[str, str] = {}
         if path.lower().endswith(".json"):
             try:
                 data = json.loads(text)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
-
-import json, re, pathlib, sys
+import json
+import pathlib
+import re
+import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
 

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from parseo import assemble, assemble_auto, clear_schema_cache, parse_auto
+from parseo import assemble, assemble_auto, clear_schema_cache
 
 
 def test_assemble_clms_fsc_schema():

--- a/tests/test_cz_schema.py
+++ b/tests/test_cz_schema.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from parseo import assemble, assemble_auto, parse_auto
+
+
+def _schema_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "src/parseo/schemas/copernicus/cz/cz_filename_v0_0_0.json"
+
+
+def test_assemble_cz_schema():
+    schema = _schema_path()
+    fields = {
+        "prefix": "CZ",
+        "product": "FOO",
+        "tile_id": "T32TNS",
+        "date": "20210101",
+        "version": "V100",
+        "extension": "gpkg",
+    }
+    result = assemble(schema, fields)
+    assert result == "CZ_FOO_T32TNS_20210101_V100.gpkg"
+
+
+def test_cz_roundtrip_auto():
+    name = "CZ_FOO_T32TNS_20210101_V100.gpkg"
+    res = parse_auto(name)
+    assert res.fields["product"] == "FOO"
+    assert res.fields["tile_id"] == "T32TNS"
+    assert res.fields["date"] == "20210101"
+    assert res.fields["version"] == "V100"
+    assert assemble_auto(res.fields) == name
+
+
+def test_cz_vector_roundtrip_auto():
+    name = "CZ_BAR_T32TNS_20210202_V101.zip"
+    res = parse_auto(name)
+    assert res.fields["product"] == "BAR"
+    assert res.fields["extension"] == "zip"
+    assert assemble_auto(res.fields) == name

--- a/tests/test_stac_scraper.py
+++ b/tests/test_stac_scraper.py
@@ -1,7 +1,6 @@
 import sys
 import types
 import json
-from pathlib import Path
 import datetime
 
 import pytest


### PR DESCRIPTION
## Summary
- restrict CZ schema to vector products only
- adjust tests for CZ gpkg and zip datasets

## Testing
- `ruff check src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acbe7084d483279b97704f7111bf3d