### PR TITLE
Raise errors for missing STAC dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ for cid in stac_scraper.list_collections(stac_url):
 ```
 
 This functionality depends on the ``pystac-client`` and ``requests``
-packages being available at runtime.
+packages being available at runtime.  If either is missing an
+``ImportError`` is raised.
 
 ---
 

--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -18,11 +18,16 @@ def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
     this variant requires the optional ``pystac-client`` dependency.  It is
     suitable when more advanced STAC handling is needed, at the cost of pulling
     in the external library.
+
+    Raises
+    ------
+    ImportError
+        If ``pystac-client`` is not installed.
     """
     try:
         from pystac_client import Client
     except Exception as exc:  # pragma: no cover - exercised when dependency missing
-        raise SystemExit(
+        raise ImportError(
             "pystac-client is required for list_collections_client"
         ) from exc
 
@@ -67,6 +72,8 @@ def search_stac_and_download(
 
     Raises
     ------
+    ImportError
+        If ``pystac-client`` or ``requests`` is not installed.
     FileNotFoundError
         If the STAC search yields no downloadable assets or all downloads
         fail.
@@ -75,14 +82,16 @@ def search_stac_and_download(
     try:
         from pystac_client import Client
     except Exception as exc:  # pragma: no cover - exercised when dependency missing
-        raise SystemExit(
+        raise ImportError(
             "pystac-client is required for search_stac_and_download"
         ) from exc
 
     try:
         import requests
     except Exception as exc:  # pragma: no cover - exercised when dependency missing
-        raise SystemExit("requests is required for search_stac_and_download") from exc
+        raise ImportError(
+            "requests is required for search_stac_and_download"
+        ) from exc
 
     client = Client.open(stac_url)
     search = client.search(collections=collections, bbox=bbox, datetime=datetime)

--- a/tests/test_stac_scraper.py
+++ b/tests/test_stac_scraper.py
@@ -1,6 +1,5 @@
 import sys
 import types
-from pathlib import Path
 
 import pytest
 import parseo.stac_scraper as ss
@@ -125,6 +124,53 @@ def test_search_stac_and_download_http_error(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "requests", fake_requests)
 
     with pytest.raises(FileNotFoundError):
+        ss.search_stac_and_download(
+            stac_url="http://base",
+            collections=["C"],
+            bbox=[0, 0, 1, 1],
+            datetime="2024",
+            dest_dir=tmp_path,
+        )
+
+
+def test_missing_pystac_client(monkeypatch, tmp_path):
+    import builtins
+
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pystac_client":
+            raise ModuleNotFoundError
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError):
+        ss.list_collections_client("http://base")
+    with pytest.raises(ImportError):
+        ss.search_stac_and_download(
+            stac_url="http://base",
+            collections=["C"],
+            bbox=[0, 0, 1, 1],
+            datetime="2024",
+            dest_dir=tmp_path,
+        )
+
+
+def test_missing_requests(monkeypatch, tmp_path):
+    fake_pc = types.SimpleNamespace(Client=FakeClientSearch)
+    monkeypatch.setitem(sys.modules, "pystac_client", fake_pc)
+
+    import builtins
+
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "requests":
+            raise ModuleNotFoundError
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError):
         ss.search_stac_and_download(
             stac_url="http://base",
             collections=["C"],


### PR DESCRIPTION
## Summary
- raise `ImportError` instead of `SystemExit` when `pystac-client` or `requests` are missing
- document new behavior in STAC scraper helpers and README
- test that missing optional STAC dependencies surface as `ImportError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad723fbe948327a3cbd457fdfb9bc0