### PR TITLE
Add helper for schema example validation

### DIFF
--- a/tests/test_schema_examples_round_trip.py
+++ b/tests/test_schema_examples_round_trip.py
@@ -1,22 +1,7 @@
 import parseo.parser as parser
-from parseo.parser import parse_auto
-from parseo import assemble
 
 
 def test_schema_examples_round_trip():
-    pkg = parser.__package__
-    parser._get_schema_paths.cache_clear()
-    for schema_path in parser._get_schema_paths(pkg):
-        schema = parser._load_json_from_path(schema_path)
-        examples = schema.get("examples")
-        if not isinstance(examples, list):
-            continue
-        for example in examples:
-            if not isinstance(example, str):
-                continue
-            result = parse_auto(example)
-            assert result.valid, f"Parsing failed for {example}"
-            fields = {k: v for k, v in result.fields.items() if v is not None}
-            assembled = assemble(schema_path, fields)
-            assert assembled == example
+    failures = parser.validate_schema_examples()
+    assert not failures, failures
 


### PR DESCRIPTION
## Summary
- add `validate_schema_examples` helper to ensure schema examples parse and assemble cleanly
- simplify schema round-trip test to use helper

## Testing
- `pytest tests/test_schema_examples_round_trip.py -q`
- `pre-commit run --files src/parseo/parser.py tests/test_schema_examples_round_trip.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad758c24f88327a7d7b96617de1c06