### PR TITLE
Add schema example validation helper and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ print(filename)
 # -> S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE
 ```
 
+### Validate schema examples
+
+When adding a new schema, use `validate_schema_examples` to ensure that the
+filenames listed under its `examples` section still parse and reassemble
+correctly.
+
+```python
+from parseo.parser import validate_schema_examples
+
+validate_schema_examples("src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json")
+```
+
+The project's tests call this helper so that schema examples stay in sync with
+the parser over time.
+
 ### Run as a web API
 
 parsEO functions can be exposed through a web service. The example below uses

--- a/tests/test_schema_examples_round_trip.py
+++ b/tests/test_schema_examples_round_trip.py
@@ -1,22 +1,6 @@
-import parseo.parser as parser
-from parseo.parser import parse_auto
-from parseo import assemble
+from parseo.parser import validate_schema_examples
 
 
 def test_schema_examples_round_trip():
-    pkg = parser.__package__
-    parser._get_schema_paths.cache_clear()
-    for schema_path in parser._get_schema_paths(pkg):
-        schema = parser._load_json_from_path(schema_path)
-        examples = schema.get("examples")
-        if not isinstance(examples, list):
-            continue
-        for example in examples:
-            if not isinstance(example, str):
-                continue
-            result = parse_auto(example)
-            assert result.valid, f"Parsing failed for {example}"
-            fields = {k: v for k, v in result.fields.items() if v is not None}
-            assembled = assemble(schema_path, fields)
-            assert assembled == example
+    validate_schema_examples()
 


### PR DESCRIPTION
## Summary
- document validate_schema_examples usage alongside parse/assemble examples
- add validate_schema_examples utility and use it in tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad758e6c3c8327a1023be942ddb634