### PR TITLE
Add schemas for Copernicus HRL products

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Currently included schemas cover:
   - Corine Land Cover (CLC)
   - High Resolution Vegetation Phenology & Productivity (HR-VPP)
   - High Resolution Water & Snow / Ice (HR-WSI)
+  - High Resolution Layers (HRL): Imperviousness, Tree Cover Density, Forest Type, Grassland, Water & Wetness, Small Woody Features
 ---
 
 ## Installation

--- a/src/parseo/schemas/copernicus/clms/hrl/forest-type/forest-type_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/forest-type/forest-type_filename_v0_0_0.json
@@ -1,0 +1,19 @@
+{
+  "schema_id": "copernicus:clms:hrl:forest-type",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS High Resolution Layer Forest Type product filename.",
+  "fields": {
+    "product": {"type": "string", "enum": ["FTY"], "description": "Product code"},
+    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "{product}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
+  "examples": [
+    "FTY_2018_E042N018_010m_V100.tif"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/forest-type/index.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/forest-type/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HRL-Forest-Type",
+    "versions": [
+        {
+            "file": "forest-type_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/grassland/grassland_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/grassland/grassland_filename_v0_0_0.json
@@ -1,0 +1,19 @@
+{
+  "schema_id": "copernicus:clms:hrl:grassland",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS High Resolution Layer Grassland product filename.",
+  "fields": {
+    "product": {"type": "string", "enum": ["GRA"], "description": "Product code"},
+    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "{product}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
+  "examples": [
+    "GRA_2018_E042N018_010m_V100.tif"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/grassland/index.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/grassland/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HRL-Grassland",
+    "versions": [
+        {
+            "file": "grassland_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v0_0_0.json
@@ -1,0 +1,19 @@
+{
+  "schema_id": "copernicus:clms:hrl:imperviousness",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS High Resolution Layer Imperviousness product filename.",
+  "fields": {
+    "product": {"type": "string", "enum": ["IMD"], "description": "Product code"},
+    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "{product}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
+  "examples": [
+    "IMD_2021_E042N018_010m_V100.tif"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/imperviousness/index.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imperviousness/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HRL-Imperviousness",
+    "versions": [
+        {
+            "file": "imperviousness_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/index.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HRL-Small-Woody-Features",
+    "versions": [
+        {
+            "file": "small-woody-features_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_0.json
@@ -1,0 +1,19 @@
+{
+  "schema_id": "copernicus:clms:hrl:small-woody-features",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS High Resolution Layer Small Woody Features product filename.",
+  "fields": {
+    "product": {"type": "string", "enum": ["SWF"], "description": "Product code"},
+    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "{product}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
+  "examples": [
+    "SWF_2018_E042N018_010m_V100.tif"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/index.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HRL-Tree-Cover-Density",
+    "versions": [
+        {
+            "file": "tree-cover-density_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/tree-cover-density_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/tree-cover-density_filename_v0_0_0.json
@@ -1,0 +1,19 @@
+{
+  "schema_id": "copernicus:clms:hrl:tree-cover-density",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS High Resolution Layer Tree Cover Density product filename.",
+  "fields": {
+    "product": {"type": "string", "enum": ["TCD"], "description": "Product code"},
+    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "{product}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
+  "examples": [
+    "TCD_2018_E042N018_010m_V100.tif"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/water-wetness/index.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/water-wetness/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HRL-Water-Wetness",
+    "versions": [
+        {
+            "file": "water-wetness_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrl/water-wetness/water-wetness_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/water-wetness/water-wetness_filename_v0_0_0.json
@@ -1,0 +1,19 @@
+{
+  "schema_id": "copernicus:clms:hrl:water-wetness",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS High Resolution Layer Water & Wetness product filename.",
+  "fields": {
+    "product": {"type": "string", "enum": ["WAW"], "description": "Product code"},
+    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "{product}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
+  "examples": [
+    "WAW_2018_E042N018_010m_V100.tif"
+  ]
+}


### PR DESCRIPTION
## Summary
- add CLMS High Resolution Layer schema directories
- define initial filename schemas for imperviousness, tree-cover-density, forest-type, grassland, water-wetness and small-woody-features
- document HRL support in CLI README

## Testing
- `pytest`
- `pre-commit run --files README.md src/parseo/schemas/copernicus/clms/hrl/imperviousness/index.json src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v0_0_0.json src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/index.json src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/tree-cover-density_filename_v0_0_0.json src/parseo/schemas/copernicus/clms/hrl/forest-type/index.json src/parseo/schemas/copernicus/clms/hrl/forest-type/forest-type_filename_v0_0_0.json src/parseo/schemas/copernicus/clms/hrl/grassland/index.json src/parseo/schemas/copernicus/clms/hrl/grassland/grassland_filename_v0_0_0.json src/parseo/schemas/copernicus/clms/hrl/water-wetness/index.json src/parseo/schemas/copernicus/clms/hrl/water-wetness/water-wetness_filename_v0_0_0.json src/parseo/schemas/copernicus/clms/hrl/small-woody-features/index.json src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_0.json` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ad94bcc6bc8327baf806872ec57889