### PR TITLE
Consolidate HR-VPP vegetation index schema

### DIFF
--- a/src/parseo/assembler.py
+++ b/src/parseo/assembler.py
@@ -159,7 +159,27 @@ def _select_schema_by_first_compulsory(fields: Dict[str, Any]) -> Path:
         if not order:
             continue
 
-        first_key = order[0]
+        specs = sch.get("fields", {})
+        first_key = None
+        for name in order:
+            spec = specs.get(name, {})
+            enums = spec.get("enum")
+            field_val = fields.get(name)
+            if enums is not None:
+                enums = [str(e) for e in enums]
+                if len(enums) == 1 and field_val == enums[0]:
+                    continue
+                if field_val is not None and field_val not in enums:
+                    first_key = None
+                    break
+                first_key = name
+                break
+            else:
+                first_key = name
+                break
+        if not first_key:
+            continue
+
         seen_first_keys.add(first_key)
 
         if first_key not in fields:

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/dmp/index.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/dmp/index.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "family": "HR-VPP-FAPAR",
+    "family": "HR-VPP-DMP",
     "versions": [
         {
             "file": "../vegetation_index_filename_v0_0_0.json",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/fcover/index.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/fcover/index.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "family": "HR-VPP-FAPAR",
+    "family": "HR-VPP-FCOVER",
     "versions": [
         {
             "file": "../vegetation_index_filename_v0_0_0.json",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/lai/index.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/lai/index.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "family": "HR-VPP-FAPAR",
+    "family": "HR-VPP-LAI",
     "versions": [
         {
             "file": "../vegetation_index_filename_v0_0_0.json",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/ndvi/index.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/ndvi/index.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "family": "HR-VPP-FAPAR",
+    "family": "HR-VPP-NDVI",
     "versions": [
         {
             "file": "../vegetation_index_filename_v0_0_0.json",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/ppi/index.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/ppi/index.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "family": "HR-VPP-FAPAR",
+    "family": "HR-VPP-PPI",
     "versions": [
         {
             "file": "../vegetation_index_filename_v0_0_0.json",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vegetation_index_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vegetation_index_filename_v0_0_0.json
@@ -1,18 +1,18 @@
 {
-  "schema_id": "copernicus:clms:hr-vpp:fapar",
+  "schema_id": "copernicus:clms:hr-vpp:vegetation-index",
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-VPP Fraction of Absorbed Photosynthetically Active Radiation product filename.",
+  "description": "CLMS HR-VPP Vegetation Indices (FAPAR, LAI, NDVI, PPI, FCOVER, DMP) product filename.",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_VPP"], "description": "Constant prefix"},
-    "product": {"type": "string", "enum": ["FAPAR"], "description": "Product code"},
+    "product": {"type": "string", "enum": ["FAPAR", "LAI", "NDVI", "PPI", "FCOVER", "DMP"], "description": "Product code"},
     "resolution": {"type": "string", "enum": ["100m"], "description": "Spatial resolution"},
     "tile_id": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "UTM tile identifier"},
     "start_date": {"type": "string", "pattern": "^\\d{8}$", "description": "Start date (YYYYMMDD)"},
     "end_date": {"type": "string", "pattern": "^\\d{8}$", "description": "End date (YYYYMMDD)"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "file_id": {"type": "string", "enum": ["FAPAR", "MTD"], "description": "File identifier"},
+    "file_id": {"type": "string", "enum": ["FAPAR", "LAI", "NDVI", "PPI", "FCOVER", "DMP", "MTD"], "description": "File identifier"},
     "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
   },
   "template": "{prefix}_{product}_{resolution}_{tile_id}_{start_date}_{end_date}_{version}_{file_id}[.{extension}]",


### PR DESCRIPTION
## Summary
- collapse NDVI, LAI, FAPAR, PPI, FCOVER and DMP filename definitions into a single HR-VPP vegetation index schema and update product indices to reference it
- simplify assembler tests to exercise the shared schema for all vegetation index products
- drop redundant HR-VPP-specific assembler test file

## Testing
- `pytest -q`
- `pre-commit run --files tests/test_hr_vpp_assembler.py` *(command not found: pre-commit)*
- `pip install pre-commit` *(Could not find a version that satisfies the requirement pre-commit (from versions: none); No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad948bffc48327a81aa4cade1fb3ff