### PR TITLE
Clarify schema extension fields

### DIFF
--- a/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "Corine Land Cover product filename.",
+  "description": "Corine Land Cover product filename (extension optional).",
   "fields": {
     "project": {
       "type": "string",
@@ -32,7 +32,7 @@
     },
     "extension": {
       "type": "string",
-      "pattern": "^[A-Za-z0-9]+$",
+      "enum": ["tif"],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st/st_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-VPP Seasonal Trajectories Plant Phenology Index product filename.",
+  "description": "CLMS HR-VPP Seasonal Trajectories Plant Phenology Index product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["ST"], "description": "Constant prefix"},
     "timestamp": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition timestamp (YYYYMMDDTHHMMSS)"},

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vegetation_index_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vegetation_index_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-VPP Vegetation Indices (FAPAR, LAI, NDVI, PPI, FCOVER, DMP) product filename.",
+  "description": "CLMS HR-VPP Vegetation Indices (FAPAR, LAI, NDVI, PPI, FCOVER, DMP) product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_VPP"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["FAPAR", "LAI", "NDVI", "PPI", "FCOVER", "DMP"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/cc/cc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/cc/cc_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-WSI Cloud Cover product filename.",
+  "description": "CLMS HR-WSI Cloud Cover product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["CC"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/fsc/fsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/fsc/fsc_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-WSI Fractional Snow Cover product filename.",
+  "description": "CLMS HR-WSI Fractional Snow Cover product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["FSC"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc/gfsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc/gfsc_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-WSI Gap-filled Fractional Snow Cover product filename.",
+  "description": "CLMS HR-WSI Gap-filled Fractional Snow Cover product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["GFSC"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/icd/icd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/icd/icd_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-WSI Ice Cover Duration product filename.",
+  "description": "CLMS HR-WSI Ice Cover Duration product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["ICD"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_comb/sp_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_comb/sp_comb_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-WSI Snow Products combination filename.",
+  "description": "CLMS HR-WSI Snow Products combination filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["SP"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_s2/sp_s2_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_s2/sp_s2_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-WSI Snow Products Sentinel-2 source filename.",
+  "description": "CLMS HR-WSI Snow Products Sentinel-2 source filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["SP"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sws/sws_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sws/sws_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-WSI Small Water Surface product filename.",
+  "description": "CLMS HR-WSI Small Water Surface product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["SWS"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wds/wds_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wds/wds_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-WSI Water Detection and Surface Displacement product filename.",
+  "description": "CLMS HR-WSI Water Detection and Surface Displacement product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["WDS"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb/wic_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb/wic_comb_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-WSI Water and Ice Cover combination filename.",
+  "description": "CLMS HR-WSI Water and Ice Cover combination filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["WIC"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_s1/wic_s1_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_s1/wic_s1_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-WSI Water and Ice Cover Sentinel-1 product filename.",
+  "description": "CLMS HR-WSI Water and Ice Cover Sentinel-1 product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["WIC"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_s2/wic_s2_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_s2/wic_s2_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS HR-WSI Water and Ice Cover Sentinel-2 product filename.",
+  "description": "CLMS HR-WSI Water and Ice Cover Sentinel-2 product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
     "product": {"type": "string", "enum": ["WIC"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hrl/forest-type/forest-type_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/forest-type/forest-type_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS High Resolution Layer Forest Type product filename.",
+  "description": "CLMS High Resolution Layer Forest Type product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["FTY"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},

--- a/src/parseo/schemas/copernicus/clms/hrl/grassland/grassland_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/grassland/grassland_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS High Resolution Layer Grassland product filename.",
+  "description": "CLMS High Resolution Layer Grassland product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["GRA"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},

--- a/src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS High Resolution Layer Imperviousness product filename.",
+  "description": "CLMS High Resolution Layer Imperviousness product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["IMD"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},

--- a/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS High Resolution Layer Small Woody Features product filename.",
+  "description": "CLMS High Resolution Layer Small Woody Features product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["SWF"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},

--- a/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/tree-cover-density_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/tree-cover-density_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS High Resolution Layer Tree Cover Density product filename.",
+  "description": "CLMS High Resolution Layer Tree Cover Density product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["TCD"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},

--- a/src/parseo/schemas/copernicus/clms/hrl/water-wetness/water-wetness_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/water-wetness/water-wetness_filename_v0_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
-  "description": "CLMS High Resolution Layer Water & Wetness product filename.",
+  "description": "CLMS High Resolution Layer Water & Wetness product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["WAW"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},

--- a/src/parseo/schemas/eumetsat/metop/metop_filename_v1_0_0.json
+++ b/src/parseo/schemas/eumetsat/metop/metop_filename_v1_0_0.json
@@ -1,6 +1,7 @@
 {
   "schema_id": "eumetsat:metop",
   "schema_version": "1.0.0",
+  "description": "EUMETSAT Metop product filename (extension optional).",
   "fields": {
     "platform": {
       "type": "string",

--- a/src/parseo/schemas/eumetsat/mtg/mtg_filename_v1_0_0.json
+++ b/src/parseo/schemas/eumetsat/mtg/mtg_filename_v1_0_0.json
@@ -1,6 +1,7 @@
 {
   "schema_id": "eumetsat:mtg",
   "schema_version": "1.0.0",
+  "description": "EUMETSAT MTG product filename (extension optional).",
   "fields": {
     "platform": {
       "type": "string",

--- a/src/parseo/schemas/nasa/modis/modis_filename_v1_0_0.json
+++ b/src/parseo/schemas/nasa/modis/modis_filename_v1_0_0.json
@@ -2,7 +2,7 @@
   "schema_id": "nasa:modis:modis",
   "schema_version": "1.0.0",
   "stac_version": "1.1.0",
-  "description": "MODIS product filename.",
+  "description": "MODIS product filename (extension optional).",
   "fields": {
     "platform": {
       "type": "string",

--- a/src/parseo/schemas/usgs/landsat/landsat_filename_v1_0_0.json
+++ b/src/parseo/schemas/usgs/landsat/landsat_filename_v1_0_0.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "eo"],
-  "description": "Landsat Collection 2 scene identifier.",
+  "description": "Landsat Collection 2 scene identifier (extension optional).",
   "fields": {
     "mission_code": {"type": "string", "enum": ["LT04", "LT05", "LE07", "LC08", "LC09"], "description": "Platform and sensor code"},
     "processing_level": {"type": "string", "enum": ["L1TP", "L1GT", "L1GS", "L2SP", "L2SR"], "description": "Processing level"},


### PR DESCRIPTION
## Summary
- document optional extensions in multiple schema descriptions
- restrict CLC schema extension to `tif`
- add missing descriptions for EUMETSAT MTG and Metop schemas

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae11bf8f8c8327a5ceef877d03a1b9