### PR TITLE
fix: simplify MODIS schema identifier

### DIFF
--- a/src/parseo/schemas/nasa/modis/modis_filename_v1_0_0.json
+++ b/src/parseo/schemas/nasa/modis/modis_filename_v1_0_0.json
@@ -1,5 +1,5 @@
 {
-  "schema_id": "nasa:modis:modis",
+  "schema_id": "nasa:modis",
   "schema_version": "1.0.0",
   "stac_version": "1.1.0",
   "description": "MODIS product filename.",


### PR DESCRIPTION
## Summary
- update MODIS filename schema id to `nasa:modis`

## Testing
- `pytest`
- (failed) `pre-commit run --files src/parseo/schemas/nasa/modis/modis_filename_v1_0_0.json src/parseo/schemas/nasa/modis/index.json` (pre-commit missing, install failed: Could not find a version that satisfies the requirement pre-commit)


------
https://chatgpt.com/codex/tasks/task_e_68ae11c193a08327a463ee79cf50aef7