### PR TITLE
Add skeleton filename schema example

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ parseo assemble \
 
 Adding support for a new product requires only a JSON schema placed under
 `src/parseo/schemas/`. All field definitions live inside the schema file.
+For a starting point, see the skeleton schema and index under
+`examples/schema_skeleton/`.
 
 1. **Create the product directory**
    - Path: `src/parseo/schemas/<family>/<mission>/<product>/`

--- a/examples/schema_skeleton/index.json
+++ b/examples/schema_skeleton/index.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "family": "TEMPLATE",
+  "versions": [
+    {
+      "status": "current",
+      "file": "template_filename_v0_0_1.json",
+      "version": "0.0.1"
+    }
+  ]
+}

--- a/examples/schema_skeleton/template_filename_v0_0_1.json
+++ b/examples/schema_skeleton/template_filename_v0_0_1.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "template:example:product",
+  "schema_version": "0.0.1",
+  "stac_version": "1.1.0",
+  "stac_extensions": [],
+  "description": "Skeleton filename schema. Replace placeholders with product-specific details.",
+  "fields": {
+    "prefix": {
+      "type": "string",
+      "pattern": "^PRD$",
+      "description": "Static prefix identifying the product family"
+    },
+    "product": {
+      "type": "string",
+      "pattern": "^XYZ$",
+      "description": "Product code or identifier"
+    },
+    "sensing_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition datetime (UTC, YYYYMMDDTHHMMSS)"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Processing baseline or version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["tif"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "required": ["prefix", "product", "sensing_datetime", "version"],
+  "template": "{prefix}_{product}_{sensing_datetime}_{version}[.{extension}]",
+  "examples": [
+    "PRD_XYZ_20240101T000000_V100.tif"
+  ]
+}


### PR DESCRIPTION
## Summary
- add example skeleton schema and index for new filename definitions
- document skeleton schema location in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae8dc2f90c83278e7bcd96ade692f9