### PR TITLE
Remove legacy assembly fallback

### DIFF
--- a/src/parseo/assembler.py
+++ b/src/parseo/assembler.py
@@ -69,9 +69,9 @@ def _assemble_from_template(template: str, fields: Dict[str, Any]) -> str:
 def assemble(schema_path: str | Path, fields: Dict[str, Any]) -> str:
     """Assemble a filename using a JSON schema.
 
-    Schemas may define a ``template`` string following parseo's mini-template
-    syntax. If present, the template is used for rendering the final filename.
-    Otherwise the legacy ``fields_order`` + ``joiner`` approach is used.
+    Schemas must define a ``template`` string following parseo's mini-template
+    syntax. The template is rendered using the provided *fields* and optional
+    segments are dropped if any enclosed field is missing.
     """
 
     sch = _load_schema(schema_path)
@@ -94,36 +94,17 @@ def assemble(schema_path: str | Path, fields: Dict[str, Any]) -> str:
                     f"Field '{name}' with value {value!r} does not match pattern {spec['pattern']}."
                 )
 
-    if isinstance(sch.get("template"), str):
-        template = sch["template"]
-        if not sch.get("fields_order"):
-            _, order = compile_template(template, sch.get("fields", {}))
-            sch["fields_order"] = order
-        try:
-            return _assemble_from_template(template, fields)
-        except KeyError as exc:
-            name = exc.args[0]
-            raise ValueError(
-                f"Missing field '{name}' for schema {schema_path}"
-            ) from exc
+    template = sch.get("template")
+    if not isinstance(template, str):
+        raise ValueError(f"Schema {schema_path} missing 'template' string.")
 
-    order = sch.get("fields_order")
-    if not order or not isinstance(order, list):
-        raise ValueError(f"Schema {schema_path} missing 'fields_order' list.")
-
-    joiner = sch.get("joiner", "_")
-
-    parts: list[str] = []
-    for key in order:
-        if key not in fields:
-            raise ValueError(f"Missing field '{key}' required by schema {schema_path}.")
-        val = fields[key]
-        if not isinstance(val, (str, int, float)):
-            raise ValueError(f"Field '{key}' must be string/number, got {type(val).__name__}.")
-        parts.append(str(val))
-
-    filename = joiner.join(parts)
-    return filename
+    try:
+        return _assemble_from_template(template, fields)
+    except KeyError as exc:
+        name = exc.args[0]
+        raise ValueError(
+            f"Missing field '{name}' for schema {schema_path}"
+        ) from exc
 
 
 def _iter_schema_paths() -> list[Path]:
@@ -137,10 +118,10 @@ def _iter_schema_paths() -> list[Path]:
 def _select_schema_by_first_compulsory(fields: Dict[str, Any]) -> Path:
     """Select the most appropriate schema based on provided fields.
 
-    Eligibility requires that the user provided the first compulsory field
-    listed in ``fields_order``. Among eligible schemas the one with the
-    largest overlap of provided keys is chosen. A longer ``fields_order``
-    acts as a tie breaker.
+    Eligibility requires the user to provide the first compulsory field as
+    derived from the schema's template. Among eligible schemas the one with the
+    largest overlap of provided keys is chosen. A longer field order acts as a
+    tie breaker.
     """
     best: tuple[int, int, str] | None = None
     best_path: Path | None = None
@@ -152,10 +133,11 @@ def _select_schema_by_first_compulsory(fields: Dict[str, Any]) -> Path:
         except Exception:
             continue
 
-        order = sch.get("fields_order") or []
-        if not order and isinstance(sch.get("template"), str):
-            _, order = compile_template(sch["template"], sch.get("fields", {}))
-            sch["fields_order"] = order
+        template = sch.get("template")
+        if not isinstance(template, str):
+            continue
+        _, order = compile_template(template, sch.get("fields", {}))
+        sch["fields_order"] = order
         if not order:
             continue
 

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -74,7 +74,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help=(
             "Assemble a filename from fields. "
             "Provide key=value pairs OR pipe a JSON object to stdin. "
-            "Schema is auto-selected using the schema's first compulsory field (fields_order[0])."
+            "Schema is auto-selected using the schema's first compulsory field as defined by the template."
         ),
     )
     p_asm.add_argument(

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -46,12 +46,12 @@ def test_assemble_auto_missing_field_template_schema():
 def test_clear_schema_cache(tmp_path):
     clear_schema_cache()
     schema = tmp_path / "schema.json"
-    schema.write_text('{"fields_order": ["a", "b"], "joiner": "_"}')
+    schema.write_text('{"template": "{a}_{b}"}')
     fields = {"a": "x", "b": "y"}
 
     assert assemble(schema, fields) == "x_y"
 
-    schema.write_text('{"fields_order": ["a", "b"], "joiner": "-"}')
+    schema.write_text('{"template": "{a}-{b}"}')
 
     # Cached schema remains in effect
     assert assemble(schema, fields) == "x_y"


### PR DESCRIPTION
## Summary
- drop `fields_order`/`joiner` fallback and require templates for assembly
- derive schema `fields_order` from templates when auto-selecting schemas
- update assembler cache test and CLI help for template-only approach

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af118e5ec08327964cb537afd9f281