### PR TITLE
Remove deprecated STAC collection alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ from parseo import stac_scraper
 stac_url = "https://catalogue.dataspace.copernicus.eu/stac"
 
 # List available collections and download the first matching asset for each
-for cid in stac_scraper.list_collections(stac_url):
+for cid in stac_scraper.list_collections_client(stac_url):
     print(cid)
     stac_scraper.search_stac_and_download(
         stac_url=stac_url,

--- a/src/parseo/stac_http.py
+++ b/src/parseo/stac_http.py
@@ -101,10 +101,6 @@ def list_collections_http(base_url: str, *, deep: bool = False) -> list[str]:
     return sorted(collections)
 
 
-# Backwards compatible alias until old name is fully deprecated
-list_collections = list_collections_http
-
-
 @lru_cache(maxsize=32)
 def _list_collections_cached(base_url: str) -> tuple[str, ...]:
     """Cached helper returning collection IDs for ``base_url``."""

--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -51,10 +51,6 @@ def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
     return sorted(collections)
 
 
-# Backwards compatible alias mirroring :mod:`parseo.stac_http`
-list_collections = list_collections_client
-
-
 def search_stac_and_download(
     *,
     stac_url: str,

--- a/tests/test_stac_scraper.py
+++ b/tests/test_stac_scraper.py
@@ -53,10 +53,10 @@ class FakeClientSearch(FakeClient):
 
 
 
-def test_list_collections_alias(monkeypatch):
+def test_list_collections_client(monkeypatch):
     fake_pc = types.SimpleNamespace(Client=FakeClient)
     monkeypatch.setitem(sys.modules, "pystac_client", fake_pc)
-    out = ss.list_collections("http://base")
+    out = ss.list_collections_client("http://base")
     assert out == ["A", "B"]
 
 


### PR DESCRIPTION
## Summary
- remove legacy `list_collections` alias from STAC helpers
- update tests and docs to use explicit `list_collections_http`/`list_collections_client`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af11a15b848327bb3cfa81bb1dc372