### PR TITLE
Rename HR-VPP ST tile_id field to laea_tile

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st/st_filename_v0_0_0.json
@@ -10,13 +10,13 @@
     "prefix": {"type": "string", "enum": ["ST"], "description": "Constant prefix"},
     "timestamp": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition timestamp (YYYYMMDDTHHMMSS)"},
     "sensor": {"type": "string", "enum": ["S2"], "description": "Sensor platform"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{2}[NS]\\d{2}-\\d{5}$", "description": "Regional tile identifier"},
+    "laea_tile": {"type": "string", "pattern": "^[EW]\\d{2}[NS]\\d{2}-\\d{5}$", "description": "Regional LAEA grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "product": {"type": "string", "enum": ["PPI"], "description": "Product code"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{prefix}_{timestamp}_{sensor}_{tile_id}_{resolution}_{version}_{product}[.{extension}]",
+  "template": "{prefix}_{timestamp}_{sensor}_{laea_tile}_{resolution}_{version}_{product}[.{extension}]",
   "examples": [
     "ST_20240101T123045_S2_E15N45-01234_010m_V100_PPI.tif"
   ]


### PR DESCRIPTION
## Summary
- rename `tile_id` field to `laea_tile` in HR-VPP Seasonal Trajectories schema
- clarify LAEA grid in field description
- update filename template to use `laea_tile`

## Testing
- `pre-commit run --files src/parseo/schemas/copernicus/clms/hr-vpp/st/st_filename_v0_0_0.json` *(failed: command not found)*
- `python -m pip install --quiet pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af11c2efb48327a4c6286aae24f43d