### PR TITLE
refactor: drop legacy filename pattern support

### DIFF
--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -153,11 +153,10 @@ def _compile_pattern(pattern: str) -> re.Pattern:
 
 
 def _pattern_from_schema(schema: Dict) -> Optional[str]:
-    """Return a compiled regex pattern derived from schema's template.
+    """Return a compiled regex pattern derived from a schema's template.
 
     The result is cached inside the schema object. If a ``template`` key is
-    present it is compiled via :func:`compile_template`. Otherwise a legacy
-    ``filename_pattern`` is used as-is.
+    present it is compiled via :func:`compile_template`.
     """
 
     cached = schema.get("_compiled_pattern")
@@ -172,11 +171,6 @@ def _pattern_from_schema(schema: Dict) -> Optional[str]:
         if "fields_order" not in schema and order:
             schema["fields_order"] = order
         return pattern
-
-    patt = schema.get("filename_pattern")
-    if isinstance(patt, str):
-        schema["_compiled_pattern"] = patt
-        return patt
 
     return None
 
@@ -260,14 +254,16 @@ def _explain_match_failure(name: str, schema: Dict) -> Optional[tuple[str, str, 
             field_rx = re.compile(_field_regex(spec))
             m_field = field_rx.match(name[start_pos:])
             if m_field:
-                value = m_field.group(0)
-            else:
-                end_pos = len(name)
-                for sep in ["_", ".", "-"]:
-                    idx = name.find(sep, start_pos)
-                    if idx != -1:
-                        end_pos = min(end_pos, idx)
-                value = name[start_pos:end_pos]
+                # Field value itself satisfies the specification; mismatch must
+                # stem from a later constant segment, so we cannot attribute
+                # it to this field.
+                return None
+            end_pos = len(name)
+            for sep in ["_", ".", "-"]:
+                idx = name.find(sep, start_pos)
+                if idx != -1:
+                    end_pos = min(end_pos, idx)
+            value = name[start_pos:end_pos]
             if "enum" in spec:
                 expected = f"one of {spec['enum']}"
             elif "pattern" in spec:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -75,7 +75,8 @@ def test_current_schema_default_and_explicit_version(tmp_path, monkeypatch):
         "schema_id": "x:y:abc",
         "schema_version": "2.0.0",
         "status": "current",
-        "filename_pattern": r"ABC_(?P<id>[A-Z]+)_v2\.txt",
+        "template": "ABC_{id}_v2.txt",
+        "fields": {"id": {"pattern": "[A-Z]+"}},
     }
     p1 = tmp_path / "abc_filename_v1_0_0.json"
     p2 = tmp_path / "abc_filename_v2_0_0.json"
@@ -92,10 +93,12 @@ def test_current_schema_default_and_explicit_version(tmp_path, monkeypatch):
     res = parse_auto("ABC_X_v2.txt")
     assert res.valid
     assert res.version == "2.0.0"
+    assert res.fields["id"] == "X"
 
     res_old = parse_auto("ABC_X_v1.txt")
     assert res_old.valid
     assert res_old.version == "1.0.0"
+    assert res_old.fields["id"] == "X"
 
     parser._get_schema_paths.cache_clear()
     parser._discover_family_info.cache_clear()


### PR DESCRIPTION
## Summary
- remove `filename_pattern` schema branch
- expand match failure diagnostics to avoid false negatives
- switch parser tests to template-based schema

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af119b53908327ae935b1b4732f9d1