### PR TITLE
Handle nested STAC collection aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ Known collection aliases are automatically mapped to their official STAC IDs:
 
 | Alias | STAC ID |
 |-------|---------|
-| `SENTINEL2_L2A` | `sentinel-2` |
+| `SENTINEL2_L2A` | `sentinel-2-l2a` |
+| `SENTINEL2_L1C` | `sentinel-2-l1c` |
 
 A different STAC service can be targeted by supplying its URL:
 

--- a/src/parseo/stac_http.py
+++ b/src/parseo/stac_http.py
@@ -104,8 +104,10 @@ def list_collections_http(base_url: str, *, deep: bool = False) -> list[str]:
 @lru_cache(maxsize=32)
 def _list_collections_cached(base_url: str) -> tuple[str, ...]:
     """Cached helper returning collection IDs for ``base_url``."""
-
-    return tuple(list_collections_http(base_url))
+    # Use a deep listing to include collections nested in child catalogs.
+    # This ensures that `_norm_collection_id` can resolve aliases for
+    # collections not present at the top-level of the STAC service.
+    return tuple(list_collections_http(base_url, deep=True))
 
 
 def iter_asset_filenames(

--- a/tests/test_stac_http.py
+++ b/tests/test_stac_http.py
@@ -381,3 +381,18 @@ def test_sample_collection_filenames_url_error(monkeypatch):
         "Could not connect to http://bad/collections"
     )
 
+
+def test_list_collections_cached_deep(monkeypatch):
+    """Cached collection listing should include nested catalogs."""
+
+    called = {}
+
+    def fake_list_collections_http(base_url, *, deep=False):
+        called["deep"] = deep
+        return ["A"]
+
+    sd._list_collections_cached.cache_clear()
+    monkeypatch.setattr(sd, "list_collections_http", fake_list_collections_http)
+    sd._list_collections_cached("http://x")
+    assert called["deep"] is True
+


### PR DESCRIPTION
## Summary
- expand cached STAC collection listing to traverse nested catalogs
- document additional Sentinel-2 collection aliases
- add regression test for deep collection cache

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af14e6e6a48327af8cc5e481cad2a1