### PR TITLE
refactor: rename schema validation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,13 @@ print(filename)
 
 ### Validate schema examples
 
-When adding a new schema, use `validate_schema_examples` to ensure that the
-filenames listed under its `examples` section still parse and reassemble
-correctly.
+When adding a new schema, use `validate_schema` to ensure that the filenames
+listed under its `examples` section still parse and reassemble correctly.
 
 ```python
-from parseo import validate_schema_examples
+from parseo import validate_schema
 
-validate_schema_examples("src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json")
+validate_schema("src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json")
 ```
 
 The project's tests call this helper so that schema examples stay in sync with

--- a/src/parseo/__init__.py
+++ b/src/parseo/__init__.py
@@ -1,6 +1,5 @@
-from .parser import parse_auto, validate_schema_examples
+from .parser import parse_auto, validate_schema
 from .assembler import assemble, assemble_auto, clear_schema_cache
-from .validator import validate_schema_examples
 from .schema_registry import (
     list_schema_families,
     list_schema_versions,
@@ -12,7 +11,7 @@ __all__ = [
     "assemble",
     "assemble_auto",
     "clear_schema_cache",
-    "validate_schema_examples",
+    "validate_schema",
     "list_schema_families",
     "list_schema_versions",
     "get_schema_path",

--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -327,7 +327,7 @@ def parse_auto(name: str) -> ParseResult:
     raise RuntimeError(msg)
 
 
-def validate_schema_examples(
+def validate_schema(
     paths: Iterable[str | Path] | None = None,
     pkg: str = __package__,
 ) -> None:

--- a/tests/test_schema_examples_round_trip.py
+++ b/tests/test_schema_examples_round_trip.py
@@ -1,6 +1,6 @@
-from parseo import validate_schema_examples
+from parseo import validate_schema
 
 
 def test_schema_examples_round_trip():
-    validate_schema_examples()
+    validate_schema()
 


### PR DESCRIPTION
## Summary
- remove stale validator import in package initializer
- rename `validate_schema_examples` to `validate_schema` across code and docs

## Testing
- `pytest`
- (attempted) `pre-commit run --files src/parseo/parser.py src/parseo/__init__.py tests/test_schema_examples_round_trip.py README.md` *(missing pre-commit; install failed: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68af1facb9cc832789d23533e096089d