### PR TITLE
Add CLI version flag

### DIFF
--- a/src/parseo/__init__.py
+++ b/src/parseo/__init__.py
@@ -1,3 +1,7 @@
+"""Top level package for parseo."""
+
+from importlib import metadata
+
 from .parser import parse_auto, validate_schema_examples
 from .assembler import assemble, assemble_auto, clear_schema_cache
 from .schema_registry import (
@@ -5,6 +9,30 @@ from .schema_registry import (
     list_schema_versions,
     get_schema_path,
 )
+
+try:  # pragma: no cover - import failure handled for graceful degradation
+    from . import parser  # noqa: F401  # import for side effect and re-export
+except Exception:  # ImportError and others
+    parser = None
+
+
+try:  # pragma: no cover - gracefully handle missing distribution
+    __version__ = metadata.version("parseo")
+except metadata.PackageNotFoundError:  # pragma: no cover - defensive
+    __version__ = "unknown"
+
+
+def info() -> dict[str, str]:
+    """Return information about the installed :mod:`parseo` package.
+
+    Returns
+    -------
+    dict[str, str]
+        A dictionary containing the installed version under the ``"version"`` key.
+    """
+
+    return {"version": __version__}
+
 
 __all__ = [
     "parse_auto",
@@ -15,11 +43,9 @@ __all__ = [
     "list_schema_families",
     "list_schema_versions",
     "get_schema_path",
+    "info",
+    "__version__",
 ]
 
-try:  # pragma: no cover - import failure handled for graceful degradation
-    from . import parser  # noqa: F401  # import for side effect and re-export
-except Exception:  # ImportError and others
-    pass
-else:
+if parser is not None:
     __all__.append("parser")

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -6,6 +6,7 @@ import json
 import sys
 from typing import Any, Dict, List
 
+from parseo import __version__
 from parseo.parser import parse_auto, describe_schema  # parser helpers
 from parseo.schema_registry import list_schema_families, list_schema_versions
 from parseo.stac_http import list_collections_http, sample_collection_filenames
@@ -15,6 +16,12 @@ from parseo.stac_http import list_collections_http, sample_collection_filenames
 
 def _build_arg_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(prog="parseo", description="parsEO CLI")
+    ap.add_argument(
+        "--version",
+        action="version",
+        version=f"parseo version {__version__}",
+        help="Show the installed parseo version and exit",
+    )
     sp = ap.add_subparsers(dest="cmd", required=True)
 
     # parse

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,20 @@ from parseo import cli
 from parseo.schema_registry import list_schema_families
 
 
+def test_cli_reports_version(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--version"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out.strip()
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        expected = version("parseo")
+    except PackageNotFoundError:
+        expected = "unknown"
+    assert out == f"parseo version {expected}"
+
+
 def test_cli_assemble_success(capsys):
     sys.argv = [
         "parseo",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,3 +5,16 @@ def test_star_import_exposes_parser():
     exec("from parseo import *", ns)
 
     assert ns["parser"] is parseo.parser
+
+
+def test_info_reports_version():
+    """The info function should return the installed package version."""
+    import parseo
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        expected = version("parseo")
+    except PackageNotFoundError:
+        expected = "unknown"
+
+    assert parseo.info()["version"] == expected


### PR DESCRIPTION
## Summary
- expose `parseo --version` flag in CLI to report installed package version
- cover version flag with a regression test

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af2137840c8327bff6ca0f19117d85