### PR TITLE
Fix validate_schema import in package init

### DIFF
--- a/src/parseo/__init__.py
+++ b/src/parseo/__init__.py
@@ -1,7 +1,7 @@
 """Top level package for parseo."""
 
 from importlib import metadata
-from .parser import parse_auto, validate_schema_examples
+from .parser import parse_auto, validate_schema
 from .assembler import assemble, assemble_auto, clear_schema_cache
 from .schema_registry import (
     list_schema_families,


### PR DESCRIPTION
## Summary
- fix import in `__init__.py` to expose `validate_schema`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af328ea69c8327886568b40a079ce8