### PR TITLE
Allow validate_schema to accept single path

### DIFF
--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -328,16 +328,17 @@ def parse_auto(name: str) -> ParseResult:
 
 
 def validate_schema(
-    paths: Iterable[str | Path] | None = None,
+    paths: str | Path | Iterable[str | Path] | None = None,
     pkg: str = __package__,
 ) -> None:
     """Validate example filenames declared in schema files.
 
     Parameters
     ----------
-    paths: Iterable[str | Path], optional
-        Specific schema JSON files to validate. When omitted, all bundled
-        schemas for *pkg* are checked.
+    paths: str | Path | Iterable[str | Path], optional
+        Specific schema JSON file(s) to validate. Accepts either a single path
+        or an iterable of paths. When omitted, all bundled schemas for *pkg*
+        are checked.
     pkg: str, optional
         Package name from which to discover schemas when *paths* is ``None``.
 
@@ -349,7 +350,12 @@ def validate_schema(
     """
 
     _get_schema_paths.cache_clear()
-    schema_paths = [Path(p) for p in paths] if paths else _get_schema_paths(pkg)
+    if paths is None:
+        schema_paths = _get_schema_paths(pkg)
+    elif isinstance(paths, (str, Path)):
+        schema_paths = [Path(paths)]
+    else:
+        schema_paths = [Path(p) for p in paths]
 
     from .assembler import assemble  # local import to avoid cycle
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -105,6 +105,27 @@ def test_current_schema_default_and_explicit_version(tmp_path, monkeypatch):
     parser._discover_family_info.cache_clear()
 
 
+def test_validate_schema_accepts_single_path(tmp_path, monkeypatch):
+    import json
+
+    schema = {
+        "template": "{id}.SAFE",
+        "fields": {"id": {"pattern": "[A-Z]+"}},
+        "examples": ["ABC.SAFE"],
+    }
+    schema_path = tmp_path / "abc.json"
+    schema_path.write_text(json.dumps(schema))
+
+    def fake_iter(pkg: str):
+        yield schema_path
+
+    monkeypatch.setattr(schema_registry, "_iter_schema_paths", fake_iter)
+    schema_registry._get_schema_paths.cache_clear()
+    parser._discover_family_info.cache_clear()
+
+    parser.validate_schema(paths=str(schema_path))
+
+
 def test_parsing_fails_without_current(tmp_path, monkeypatch):
     import json
 


### PR DESCRIPTION
## Summary
- allow `validate_schema` to accept a single `str` or `Path`
- document single-path usage
- add regression test for validating with a single path

## Testing
- `pytest`
- ⚠️ `pre-commit run --files src/parseo/parser.py tests/test_parser.py` *(missing: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68af37c6bde88327895d3120671afb7c