### PR TITLE
Add verbose option for schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,18 @@ print(filename)
 ### Validate schema examples
 
 When adding a new schema, use `validate_schema` to ensure that the filenames
-listed under its `examples` section still parse and reassemble correctly.
+listed under its `examples` section still parse and reassemble correctly. Pass
+`verbose=True` to get feedback as each example is checked.
 
 ```python
 from parseo import validate_schema
 
 validate_schema("src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json")
+# Enable verbose output to see progress
+validate_schema(
+    "src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json",
+    verbose=True,
+)
 ```
 
 The project's tests call this helper so that schema examples stay in sync with

--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -330,6 +330,7 @@ def parse_auto(name: str) -> ParseResult:
 def validate_schema(
     paths: str | Path | Iterable[str | Path] | None = None,
     pkg: str = __package__,
+    verbose: bool = False,
 ) -> None:
     """Validate example filenames declared in schema files.
 
@@ -341,6 +342,9 @@ def validate_schema(
         are checked.
     pkg: str, optional
         Package name from which to discover schemas when *paths* is ``None``.
+    verbose: bool, optional
+        When ``True``, print each schema path and example as they are validated,
+        along with a summary count of successful validations.
 
     Raises
     ------
@@ -359,7 +363,10 @@ def validate_schema(
 
     from .assembler import assemble  # local import to avoid cycle
 
+    validated = 0
     for schema_path in schema_paths:
+        if verbose:
+            print(schema_path)
         schema = _load_json_from_path(schema_path)
         examples = schema.get("examples")
         if not isinstance(examples, list):
@@ -374,4 +381,9 @@ def validate_schema(
             assembled = assemble(fields, schema_path=schema_path)
             if assembled != example:
                 raise ValueError(f"Round trip failed for {example}")
+            validated += 1
+            if verbose:
+                print(f"  {example}")
+    if verbose:
+        print(f"Validated {validated} examples")
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -104,7 +104,7 @@ def test_current_schema_default_and_explicit_version(tmp_path, monkeypatch):
     schema_registry.clear_cache()
 
 
-def test_validate_schema_accepts_single_path(tmp_path, monkeypatch):
+def test_validate_schema_accepts_single_path(tmp_path, monkeypatch, capsys):
     import json
 
     schema = {
@@ -121,7 +121,17 @@ def test_validate_schema_accepts_single_path(tmp_path, monkeypatch):
     monkeypatch.setattr(schema_registry, "_iter_schema_paths", fake_iter)
     schema_registry.clear_cache()
 
+    # Silent mode should produce no output
     parser.validate_schema(paths=str(schema_path))
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+    # Verbose mode should emit progress and summary
+    parser.validate_schema(paths=str(schema_path), verbose=True)
+    captured = capsys.readouterr()
+    assert str(schema_path) in captured.out
+    assert "ABC.SAFE" in captured.out
+    assert "Validated 1 examples" in captured.out
 
 
 def test_parsing_fails_without_current(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- allow `validate_schema` to log schema paths and examples
- test verbose and silent schema validation
- document `verbose=True` in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af568e2a30832780d0af1bf0a98eac