### PR TITLE
Add repository AGENTS guide and tidy imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS
+
+These instructions apply to the entire repository.
+
+## Code style
+- Target Python 3.9+ features.
+- Use [ruff](https://docs.astral.sh/ruff/) to lint and format code. Run `ruff check .` before committing and address reported issues.
+- Keep one import per line and sort imports alphabetically.
+
+## Testing
+- Run `pytest` to ensure all tests pass.
+- When possible, run `ruff check .` and `pytest` before sending changes.
+
+## Development workflow
+- Use the `develop` branch as the base for changes.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
 
-import json, re, pathlib, sys
+import json
+import pathlib
+import re
+import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
 


### PR DESCRIPTION
## Summary
- add AGENTS.md describing code style, testing, and branch conventions
- split combined imports in tests/conftest.py so ruff linting passes

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afe89afc148327ab18811bf4be73a8