### PR TITLE
Use typing.Union instead of pipe unions

### DIFF
--- a/src/parseo/_json.py
+++ b/src/parseo/_json.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
+from typing import Dict
+from typing import Union
 
 
-def load_json(path: str | Path) -> Dict[str, Any]:
+def load_json(path: Union[str, Path]) -> Dict[str, Any]:
     """Load a JSON file, handling optional UTF-8 BOM."""
     p = Path(path)
     text = p.read_text(encoding="utf-8-sig")

--- a/src/parseo/assembler.py
+++ b/src/parseo/assembler.py
@@ -1,11 +1,14 @@
 # src/parseo/assembler.py
 from __future__ import annotations
 
-from importlib.resources import as_file, files
+from functools import lru_cache
+from importlib.resources import as_file
+from importlib.resources import files
 from pathlib import Path
 import re
-from typing import Any, Dict
-from functools import lru_cache
+from typing import Any
+from typing import Dict
+from typing import Union
 
 from ._json import load_json
 from .template import compile_template, _field_regex
@@ -16,7 +19,7 @@ SCHEMAS_ROOT = "schemas"
 
 
 @lru_cache(maxsize=None)
-def _load_schema(schema_path: str | Path) -> Dict[str, Any]:
+def _load_schema(schema_path: Union[str, Path]) -> Dict[str, Any]:
     return load_json(str(schema_path))
 
 
@@ -67,7 +70,7 @@ def _assemble_from_template(template: str, fields: Dict[str, Any]) -> str:
     return render(template)
 
 
-def _assemble_schema(schema_path: str | Path, fields: Dict[str, Any]) -> str:
+def _assemble_schema(schema_path: Union[str, Path], fields: Dict[str, Any]) -> str:
     """Assemble a filename using a JSON schema.
 
     Schemas must define a ``template`` string following parseo's mini-template
@@ -110,9 +113,9 @@ def _assemble_schema(schema_path: str | Path, fields: Dict[str, Any]) -> str:
 
 def assemble(
     fields: Dict[str, Any],
-    family: str | None = None,
-    version: str | None = None,
-    schema_path: str | Path | None = None,
+    family: Union[str, None] = None,
+    version: Union[str, None] = None,
+    schema_path: Union[str, Path, None] = None,
 ) -> str:
     """Assemble a filename from *fields*.
 
@@ -145,8 +148,8 @@ def _select_schema_by_first_compulsory(fields: Dict[str, Any]) -> Path:
     largest overlap of provided keys is chosen. A longer field order acts as a
     tie breaker.
     """
-    best: tuple[int, int, str] | None = None
-    best_path: Path | None = None
+    best: Union[tuple[int, int, str], None] = None
+    best_path: Union[Path, None] = None
     seen_first_keys: set[str] = set()
 
     for p in _iter_schema_paths():

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from typing import Any, Dict, List
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Union
 
 from parseo import __version__
 from parseo.parser import parse_auto, describe_schema  # parser helpers
@@ -164,7 +167,7 @@ def _resolve_fields(args) -> Dict[str, Any]:
 
 # ---------- main ----------
 
-def main(argv: List[str] | None = None) -> int:
+def main(argv: Union[List[str], None] = None) -> int:
     argv = argv if argv is not None else sys.argv[1:]
     ap = _build_arg_parser()
     args = ap.parse_args(argv)

--- a/src/parseo/clms_catalog.py
+++ b/src/parseo/clms_catalog.py
@@ -15,9 +15,11 @@ access is only required when calling :func:`fetch_clms_products`.
 from __future__ import annotations
 
 from html.parser import HTMLParser
-from typing import Iterable, List
-from urllib.request import urlopen
 import os
+from typing import Iterable
+from typing import List
+from typing import Union
+from urllib.request import urlopen
 
 
 class _DatasetTitleParser(HTMLParser):
@@ -28,7 +30,7 @@ class _DatasetTitleParser(HTMLParser):
         self._capture = False
         self.titles: List[str] = []
 
-    def handle_starttag(self, tag: str, attrs: Iterable[tuple[str, str | None]]) -> None:
+    def handle_starttag(self, tag: str, attrs: Iterable[tuple[str, Union[str, None]]]) -> None:
         if tag == "h2":
             attrs_dict = dict(attrs)
             css = attrs_dict.get("class", "") or ""
@@ -60,7 +62,7 @@ def parse_html(html: str) -> List[str]:
     return out
 
 
-def fetch_clms_products(url: str | None = None) -> List[str]:
+def fetch_clms_products(url: Union[str, None] = None) -> List[str]:
     """Fetch the CLMS dataset catalog and return all product titles.
 
     If ``url`` is not provided, the environment variable

--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -2,11 +2,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from importlib.resources import files, as_file
-from pathlib import Path
-from typing import Any, Dict, Optional, Iterable
-import re
 from functools import lru_cache
+from importlib.resources import as_file
+from importlib.resources import files
+from pathlib import Path
+import re
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import Optional
+from typing import Union
 
 from .template import compile_template, _field_regex
 from .schema_registry import (
@@ -328,7 +333,7 @@ def parse_auto(name: str) -> ParseResult:
 
 
 def validate_schema(
-    paths: str | Path | Iterable[str | Path] | None = None,
+    paths: Union[str, Path, Iterable[Union[str, Path]], None] = None,
     pkg: str = __package__,
     verbose: bool = False,
 ) -> None:
@@ -336,7 +341,7 @@ def validate_schema(
 
     Parameters
     ----------
-    paths: str | Path | Iterable[str | Path], optional
+    paths: Union[str, Path, Iterable[Union[str, Path]]], optional
         Specific schema JSON file(s) to validate. Accepts either a single path
         or an iterable of paths. When omitted, all bundled schemas for *pkg*
         are checked.

--- a/src/parseo/schema_registry.py
+++ b/src/parseo/schema_registry.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from dataclasses import field
 from functools import lru_cache
-from importlib.resources import as_file, files
+from importlib.resources import as_file
+from importlib.resources import files
 from pathlib import Path
-from typing import Dict, Iterator, Optional
 import re
+from typing import Dict
+from typing import Iterator
+from typing import Optional
+from typing import Union
 
 from ._json import load_json
 
@@ -80,7 +85,7 @@ def _discover_family_info(pkg: str) -> Dict[str, _FamilyInfo]:
         current_version = None
         current_path = None
         current_status = None
-        for ver, (p, st) in versions.items():
+        for ver, (p, st) in sorted(versions.items(), reverse=True):
             if st == "current":
                 current_version = ver
                 current_path = p
@@ -144,7 +149,7 @@ def list_schema_versions(family: str, pkg: str = __package__) -> list[dict]:
 
 @lru_cache(maxsize=256)
 def get_schema_path(
-    family: str, version: str | None = None, pkg: str = __package__
+    family: str, version: Union[str, None] = None, pkg: str = __package__
 ) -> Path:
     """Return filesystem path to schema for *family* and *version*.
 

--- a/src/parseo/stac_http.py
+++ b/src/parseo/stac_http.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
+from typing import Union
 from urllib.parse import urljoin, urlparse
 import urllib.error
 import urllib.request
@@ -115,7 +116,7 @@ def iter_asset_filenames(
     *,
     base_url: str,
     limit: int = 100,
-    asset_role: str | None = None,
+    asset_role: Union[str, None] = None,
 ) -> Iterable[str]:
     """Yield asset filenames from items of a collection.
 
@@ -192,7 +193,7 @@ def iter_collection_tree(
     *,
     base_url: str,
     limit: int = 100,
-    asset_role: str | None = None,
+    asset_role: Union[str, None] = None,
 ) -> Iterable[tuple[str, str]]:
     """Yield ``(collection_id, filename)`` pairs for all leaf collections.
 
@@ -240,7 +241,7 @@ def sample_collection_filenames(
     samples: int = 5,
     *,
     base_url: str,
-    asset_role: str | None = None,
+    asset_role: Union[str, None] = None,
 ) -> dict[str, list[str]]:
     """Return ``samples`` filenames for each leaf collection.
 

--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -8,6 +8,7 @@ only depends on the Python standard library see :mod:`parseo.stac_http`.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Union
 from urllib.parse import urlparse
 
 def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
@@ -55,9 +56,9 @@ def search_stac_and_download(
     *,
     stac_url: str,
     collections: list[str],
-    bbox: list[float] | tuple[float, float, float, float],
+    bbox: Union[list[float], tuple[float, float, float, float]],
     datetime: str,
-    dest_dir: str | Path,
+    dest_dir: Union[str, Path],
 ) -> Path:
     """Download the first asset matching a STAC search.
 

--- a/src/parseo/template.py
+++ b/src/parseo/template.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, Tuple, List
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
 
-def _field_regex(spec: Dict | None) -> str:
+def _field_regex(spec: Union[Dict, None]) -> str:
     """Return a regex for a field spec.
 
     If *spec* is missing or empty, a permissive pattern ``.+`` is used.


### PR DESCRIPTION
## Summary
- replace `|` type unions with `typing.Union` across parseo modules
- ensure schema registry picks the latest schema version marked as current

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afed1693ec8327bc9fecaef79e0601