### PR TITLE
chore: enforce single-line sorted imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,9 @@ exclude = ["tests*", "docs*", "examples*"]
 # [tool.setuptools_scm]
 # version_scheme = "release-branch-semver"
 # local_scheme = "no-local-version"
+
+[tool.ruff]
+target-version = "py39"
+
+[tool.ruff.lint.isort]
+force-single-line = true

--- a/src/parseo/__init__.py
+++ b/src/parseo/__init__.py
@@ -1,13 +1,15 @@
 """Top level package for parseo."""
 
 from importlib import metadata
-from .parser import parse_auto, validate_schema
-from .assembler import assemble, assemble_auto, clear_schema_cache
-from .schema_registry import (
-    list_schema_families,
-    list_schema_versions,
-    get_schema_path,
-)
+
+from .assembler import assemble
+from .assembler import assemble_auto
+from .assembler import clear_schema_cache
+from .parser import parse_auto
+from .parser import validate_schema
+from .schema_registry import get_schema_path
+from .schema_registry import list_schema_families
+from .schema_registry import list_schema_versions
 
 try:  # pragma: no cover - import failure handled for graceful degradation
     from . import parser  # noqa: F401  # import for side effect and re-export

--- a/src/parseo/_json.py
+++ b/src/parseo/_json.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
+from typing import Dict
 
 
 def load_json(path: str | Path) -> Dict[str, Any]:

--- a/src/parseo/assembler.py
+++ b/src/parseo/assembler.py
@@ -1,16 +1,18 @@
 # src/parseo/assembler.py
 from __future__ import annotations
 
-from importlib.resources import as_file, files
-from pathlib import Path
 import re
-from typing import Any, Dict
 from functools import lru_cache
+from importlib.resources import as_file
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+from typing import Dict
 
 from ._json import load_json
-from .template import compile_template, _field_regex
 from .schema_registry import get_schema_path
-
+from .template import _field_regex
+from .template import compile_template
 
 SCHEMAS_ROOT = "schemas"
 

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from typing import Any, Dict, List
+from typing import Any
+from typing import Dict
+from typing import List
 
 from parseo import __version__
-from parseo.parser import parse_auto, describe_schema  # parser helpers
-from parseo.schema_registry import list_schema_families, list_schema_versions
-from parseo.stac_http import list_collections_http, sample_collection_filenames
-
+from parseo.parser import describe_schema  # parser helpers
+from parseo.parser import parse_auto
+from parseo.schema_registry import list_schema_families
+from parseo.schema_registry import list_schema_versions
+from parseo.stac_http import list_collections_http
+from parseo.stac_http import sample_collection_filenames
 
 # ---------- small utilities ----------
 

--- a/src/parseo/clms_catalog.py
+++ b/src/parseo/clms_catalog.py
@@ -14,10 +14,11 @@ access is only required when calling :func:`fetch_clms_products`.
 """
 from __future__ import annotations
 
-from html.parser import HTMLParser
-from typing import Iterable, List
-from urllib.request import urlopen
 import os
+from html.parser import HTMLParser
+from typing import Iterable
+from typing import List
+from urllib.request import urlopen
 
 
 class _DatasetTitleParser(HTMLParser):

--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -1,21 +1,25 @@
-# src/parseo/parser.py
+"""Parsing helpers for parseo."""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
-from importlib.resources import files, as_file
-from pathlib import Path
-from typing import Any, Dict, Optional, Iterable
 import re
+from dataclasses import dataclass
 from functools import lru_cache
+from importlib.resources import as_file
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import Optional
 
-from .template import compile_template, _field_regex
-from .schema_registry import (
-    _discover_family_info,
-    _get_schema_paths,
-    _load_json_from_path,
-    list_schema_families,
-    get_schema_path,
-)
+from .schema_registry import _discover_family_info
+from .schema_registry import _get_schema_paths
+from .schema_registry import _load_json_from_path
+from .schema_registry import get_schema_path
+from .schema_registry import list_schema_families
+from .template import _field_regex
+from .template import compile_template
 
 # Root folder inside the package where JSON schemas live
 SCHEMAS_ROOT = "schemas"

--- a/src/parseo/schema_registry.py
+++ b/src/parseo/schema_registry.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from functools import lru_cache
-from importlib.resources import as_file, files
-from pathlib import Path
-from typing import Dict, Iterator, Optional
 import re
+from dataclasses import dataclass
+from dataclasses import field
+from functools import lru_cache
+from importlib.resources import as_file
+from importlib.resources import files
+from pathlib import Path
+from typing import Dict
+from typing import Iterator
+from typing import Optional
 
 from ._json import load_json
 

--- a/src/parseo/stac_http.py
+++ b/src/parseo/stac_http.py
@@ -7,16 +7,18 @@ functions require explicitly passing the ``base_url`` of the STAC service.
 """
 from __future__ import annotations
 
+import itertools
+import json
+import re
+import urllib.error
+import urllib.request
 from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
-from urllib.parse import urljoin, urlparse
-import urllib.error
-import urllib.request
-import json
-import itertools
-import re
 from string import Template
+from urllib.parse import urljoin
+from urllib.parse import urlparse
+
 
 def _norm_collection_id(collection_id: str, *, base_url: str) -> str:
     """Resolve ``collection_id`` to the official ID from the STAC API."""

--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.parse import urlparse
 
+
 def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
     """Return collection IDs from a STAC API using ``pystac-client``.
 

--- a/src/parseo/template.py
+++ b/src/parseo/template.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, Tuple, List
+from typing import Dict
+from typing import List
+from typing import Tuple
+
 
 def _field_regex(spec: Dict | None) -> str:
     """Return a regex for a field spec.

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -2,12 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from parseo import (
-    assemble,
-    assemble_auto,
-    clear_schema_cache,
-    list_schema_versions,
-)
+from parseo import assemble
+from parseo import assemble_auto
+from parseo import clear_schema_cache
+from parseo import list_schema_versions
 
 
 def test_assemble_missing_field_template_schema():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,14 @@
-import sys
 import builtins
 import io
-import pytest
 import json
+import sys
+
+import pytest
 
 from parseo import cli
+from parseo.parser import describe_schema
+from parseo.parser import parse_auto
 from parseo.schema_registry import list_schema_families
-from parseo.parser import parse_auto, describe_schema
 
 
 def _schema_example_args(family: str) -> tuple[str, list[str]]:
@@ -22,7 +24,8 @@ def test_cli_reports_version(capsys):
         cli.main(["--version"])
     assert exc.value.code == 0
     out = capsys.readouterr().out.strip()
-    from importlib.metadata import PackageNotFoundError, version
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version
 
     try:
         expected = version("parseo")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,8 +9,10 @@ def test_star_import_exposes_parser():
 
 def test_info_reports_version():
     """The info function should return the installed package version."""
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version
+
     import parseo
-    from importlib.metadata import PackageNotFoundError, version
 
     try:
         expected = version("parseo")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,8 +1,10 @@
-from parseo.parser import parse_auto
+from functools import lru_cache
+
+import pytest
+
 import parseo.parser as parser
 import parseo.schema_registry as schema_registry
-import pytest
-from functools import lru_cache
+from parseo.parser import parse_auto
 
 
 def test_schema_paths_cached(monkeypatch):

--- a/tests/test_stac_http.py
+++ b/tests/test_stac_http.py
@@ -1,5 +1,7 @@
-import pytest
 import urllib.error
+
+import pytest
+
 import parseo.stac_http as sd
 
 

--- a/tests/test_stac_scraper.py
+++ b/tests/test_stac_scraper.py
@@ -2,6 +2,7 @@ import sys
 import types
 
 import pytest
+
 import parseo.stac_scraper as ss
 
 


### PR DESCRIPTION
## Summary
- configure Ruff to enforce single-line imports
- alphabetize and split imports across package and tests

## Testing
- `ruff check --select I --diff`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afed0ec6548327984f1075914336c2