### PR TITLE
style: split and sort imports per guidelines

### DIFF
--- a/src/parseo/__init__.py
+++ b/src/parseo/__init__.py
@@ -1,13 +1,14 @@
 """Top level package for parseo."""
 
 from importlib import metadata
-from .parser import parse_auto, validate_schema
-from .assembler import assemble, assemble_auto, clear_schema_cache
-from .schema_registry import (
-    list_schema_families,
-    list_schema_versions,
-    get_schema_path,
-)
+from .assembler import assemble
+from .assembler import assemble_auto
+from .assembler import clear_schema_cache
+from .parser import parse_auto
+from .parser import validate_schema
+from .schema_registry import get_schema_path
+from .schema_registry import list_schema_families
+from .schema_registry import list_schema_versions
 
 try:  # pragma: no cover - import failure handled for graceful degradation
     from . import parser  # noqa: F401  # import for side effect and re-export

--- a/src/parseo/assembler.py
+++ b/src/parseo/assembler.py
@@ -11,8 +11,9 @@ from typing import Dict
 from typing import Union
 
 from ._json import load_json
-from .template import compile_template, _field_regex
 from .schema_registry import get_schema_path
+from .template import _field_regex
+from .template import compile_template
 
 
 SCHEMAS_ROOT = "schemas"

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -10,9 +10,12 @@ from typing import List
 from typing import Union
 
 from parseo import __version__
-from parseo.parser import parse_auto, describe_schema  # parser helpers
-from parseo.schema_registry import list_schema_families, list_schema_versions
-from parseo.stac_http import list_collections_http, sample_collection_filenames
+from parseo.parser import describe_schema  # parser helpers
+from parseo.parser import parse_auto
+from parseo.schema_registry import list_schema_families
+from parseo.schema_registry import list_schema_versions
+from parseo.stac_http import list_collections_http
+from parseo.stac_http import sample_collection_filenames
 
 
 # ---------- small utilities ----------

--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -13,14 +13,13 @@ from typing import Iterable
 from typing import Optional
 from typing import Union
 
-from .template import compile_template, _field_regex
-from .schema_registry import (
-    _discover_family_info,
-    _get_schema_paths,
-    _load_json_from_path,
-    list_schema_families,
-    get_schema_path,
-)
+from .schema_registry import _discover_family_info
+from .schema_registry import _get_schema_paths
+from .schema_registry import _load_json_from_path
+from .schema_registry import get_schema_path
+from .schema_registry import list_schema_families
+from .template import _field_regex
+from .template import compile_template
 
 # Root folder inside the package where JSON schemas live
 SCHEMAS_ROOT = "schemas"

--- a/src/parseo/stac_http.py
+++ b/src/parseo/stac_http.py
@@ -9,15 +9,16 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from functools import lru_cache
-from pathlib import Path
-from typing import Union
-from urllib.parse import urljoin, urlparse
-import urllib.error
-import urllib.request
-import json
 import itertools
+import json
+from pathlib import Path
 import re
 from string import Template
+from typing import Union
+import urllib.error
+from urllib.parse import urljoin
+from urllib.parse import urlparse
+import urllib.request
 
 def _norm_collection_id(collection_id: str, *, base_url: str) -> str:
     """Resolve ``collection_id`` to the official ID from the STAC API."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,14 @@
-import sys
 import builtins
 import io
-import pytest
 import json
+import sys
+
+import pytest
 
 from parseo import cli
+from parseo.parser import describe_schema
+from parseo.parser import parse_auto
 from parseo.schema_registry import list_schema_families
-from parseo.parser import parse_auto, describe_schema
 
 
 def _schema_example_args(family: str) -> tuple[str, list[str]]:
@@ -22,7 +24,8 @@ def test_cli_reports_version(capsys):
         cli.main(["--version"])
     assert exc.value.code == 0
     out = capsys.readouterr().out.strip()
-    from importlib.metadata import PackageNotFoundError, version
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version
 
     try:
         expected = version("parseo")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,7 +10,8 @@ def test_star_import_exposes_parser():
 def test_info_reports_version():
     """The info function should return the installed package version."""
     import parseo
-    from importlib.metadata import PackageNotFoundError, version
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version
 
     try:
         expected = version("parseo")


### PR DESCRIPTION
## Summary
- enforce one-name-per-line import style across modules and tests
- alphabetize imports for consistent style

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afef51e4f4832789d75bccde382ff7