### PR TITLE
Add YAML front matter for Quarto compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
+---
+title: "parsEO"
+---
+
 # parsEO
 
-**parsEO** is a Python package for **parsing and assembling filenames** of satellite data and derived products.  
+**parsEO** is a Python package for **parsing and assembling filenames** of satellite data and derived products.
 It also serves as an **authoritative definition of filename structures** through machine-readable JSON schemas.
 
 ---
@@ -36,6 +40,7 @@ It also serves as an **authoritative definition of filename structures** through
   - High Resolution Vegetation Phenology & Productivity (HR-VPP)
   - High Resolution Water & Snow / Ice (HR-WSI)
   - High Resolution Layers (HRL)
+
 ---
 
 ## Installation
@@ -184,6 +189,7 @@ The interactive page lets you call `/parse` and `/assemble` directly from the
 browser to verify the API.
 
 ---
+
 ### List STAC collections (not functional yet!)
 
 Use the ``list-stac-collections`` subcommand to list collection IDs exposed by a
@@ -444,6 +450,7 @@ one in `examples/schema_skeleton/`.
 - Include at least one positive example in the schema file
 - Run tests with `pytest`
 - submit a pull request
+
 ---
 
 ## License


### PR DESCRIPTION
## Summary
- add minimal YAML front matter so README renders with Quarto
- ensure horizontal rules are surrounded by blank lines to avoid parsing as YAML

## Testing
- `ruff check .`
- `pytest`
- ⚠️ `quarto preview README.md --no-browser --no-watch-inputs` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aff0cf6d5483279d29d2cbb2f01a23