### PR TITLE
Make assembler CLI command mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,16 +281,6 @@ packages being available at runtime.  If either is missing an
 ## Command Line Interface
 
 Use the CLI to parse filenames, list available schemas, and assemble filenames from fields.
-The `assemble` subcommand relies on the `parseo.assembler` module, which ships with the
-standard parseo installation. If you run `parseo assemble` in an environment where this
-module was intentionally omitted, the CLI will exit with:
-
-```
-The 'assemble' command requires parseo.assembler, which is part of the standard parseo installation.
-```
-
-Reinstall parseo with assembler support or provide your own `parseo/assembler.py`
-implementing `assemble(schema_path, fields)` to enable this command.
 
 The `list-clms-products` subcommand queries the public Copernicus Land Monitoring Service (CLMS)
 dataset catalog and prints the available product names. Use this to discover valid identifiers

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -10,6 +10,7 @@ from typing import List
 from typing import Union
 
 from parseo import __version__
+from parseo.assembler import assemble_auto
 from parseo.parser import describe_schema  # parser helpers
 from parseo.parser import parse_auto
 from parseo.schema_registry import list_schema_families
@@ -237,18 +238,6 @@ def main(argv: Union[List[str], None] = None) -> int:
         return 0
 
     if args.cmd == "assemble":
-        # Lazy import so 'parse' doesn’t require assembler module
-        try:
-            from parseo.assembler import assemble_auto
-        except ModuleNotFoundError:
-            raise SystemExit(
-                "The 'assemble' command requires parseo.assembler, which is part of the "
-                "standard parseo installation.\n"
-                "If it is missing, reinstall parseo with assembler support or provide a "
-                "'parseo/assembler.py' implementing 'assemble_auto(fields)'. "
-                "You can still use 'parse' or 'list-schemas'."
-            )
-
         fields = _resolve_fields(args)
         out = assemble_auto(fields)
         print(out)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-import builtins
 import io
 import json
 import sys
@@ -46,23 +45,6 @@ def test_cli_assemble_fapar_success(capsys):
     assert cli.main(["assemble", *args]) == 0
     captured = capsys.readouterr()
     assert captured.out.strip() == example
-
-def test_cli_assemble_missing_assembler(monkeypatch):
-    real_import = builtins.__import__
-
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == "parseo.assembler":
-            raise ModuleNotFoundError
-        return real_import(name, globals, locals, fromlist, level)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-    example, args = _schema_example_args("WIC")
-    with pytest.raises(SystemExit) as exc:
-        cli.main(["assemble", *args])
-    msg = str(exc.value)
-    assert "requires parseo.assembler" in msg
-    assert "standard parseo installation" in msg
-
 
 def test_fields_json_invalid_string():
     sys.argv = ["parseo", "assemble", "--fields-json", "{"]


### PR DESCRIPTION
## Summary
- import assembler at startup so `parseo assemble` is always available
- drop documentation about optional assembler module
- remove tests and code paths for missing assembler module

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aff5ba0684832781080452beaf0657