### PR TITLE
Format list-schemas output into table

### DIFF
--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -189,11 +189,27 @@ def main(argv: Union[List[str], None] = None) -> int:
         return 0
 
     if args.cmd == "list-schemas":
+        rows: list[tuple[str, str, str, str]] = []
         for fam in list_schema_families():
             for info in list_schema_versions(fam):
-                status = info.get("status") or ""
-                line = f"{fam} {info['version']} {status} {info['file']}".strip()
-                print(line)
+                rows.append(
+                    (
+                        fam,
+                        info["version"],
+                        info.get("status") or "",
+                        info["file"],
+                    )
+                )
+        if rows:
+            headers = ("FAMILY", "VERSION", "STATUS", "FILE")
+            widths = [len(h) for h in headers]
+            for row in rows:
+                for i in range(3):
+                    widths[i] = max(widths[i], len(row[i]))
+            line_fmt = f"{{:{widths[0]}}} {{:{widths[1]}}} {{:{widths[2]}}} {{}}"
+            print(line_fmt.format(*headers))
+            for row in rows:
+                print(line_fmt.format(*row))
         return 0
 
     if args.cmd == "schema-info":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,8 +69,9 @@ def test_list_schemas_exposes_known_families():
 
 def test_cli_list_schemas_outputs_versions(capsys):
     assert cli.main(["list-schemas"]) == 0
-    lines = capsys.readouterr().out.splitlines()
-    tokens = [line.split() for line in lines]
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[0].split() == ["FAMILY", "VERSION", "STATUS", "FILE"]
+    tokens = [line.split(maxsplit=3) for line in lines[1:]]
     entries = {t[0]: t for t in tokens}
     assert entries["S1"][1] == "1.0.0"
     assert entries["S2"][1] == "1.0.0"


### PR DESCRIPTION
## Summary
- Format `list-schemas` CLI output with a header row and aligned columns for readability
- Update tests to validate the new table format

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b09cfceef08327ba133a66778f85fb