### PR TITLE
Add Copernicus Urban Atlas LCU schema

### DIFF
--- a/src/parseo/schemas/copernicus/clms/urban-atlas/urban_atlas_lcu_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/urban-atlas/urban_atlas_lcu_filename_v0_0_0.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:ua-lcu",
+  "schema_version": "0.0.0",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["vector"],
+  "description": "Copernicus Urban Atlas land cover / land use 0.25 ha product filename (extension optional).",
+  "fields": {
+    "prefix": {
+      "type": "string",
+      "enum": ["CLMS"],
+      "description": "Constant programme prefix"
+    },
+    "programme": {
+      "type": "string",
+      "enum": ["UA"],
+      "description": "Programme code (Urban Atlas)"
+    },
+    "product": {
+      "type": "string",
+      "enum": ["LCU"],
+      "description": "Product theme (Land Cover / Land Use)"
+    },
+    "survey": {
+      "type": "string",
+      "pattern": "^S\\d{4}$",
+      "description": "Survey year token (e.g., S2021)"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^V\\d{3}ha$",
+      "description": "Minimum mapping unit (e.g., V025ha)"
+    },
+    "area_code": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}\\d{3}L\\d$",
+      "description": "Local administrative area code"
+    },
+    "city": {
+      "type": "string",
+      "pattern": "^[A-Z0-9-]+$",
+      "description": "City or metropolitan area identifier"
+    },
+    "tile": {
+      "type": "string",
+      "pattern": "^\\d{5}$",
+      "description": "Tile identifier"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{2}$",
+      "description": "Product version"
+    },
+    "release": {
+      "type": "string",
+      "pattern": "^R\\d{2}$",
+      "description": "Release identifier"
+    },
+    "production_date": {
+      "type": "string",
+      "pattern": "^\\d{8}$",
+      "description": "Production date (YYYYMMDD)"
+    },
+    "extension": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9]+(?:\\.[A-Za-z0-9]+)?$",
+      "description": "Optional file extension without leading dot (allows compound extensions such as gpkg.zip)"
+    }
+  },
+  "template": "{prefix}_{programme}_{product}_{survey}_{resolution}_{area_code}_{city}_{tile}_{version}_{release}_{production_date}[.{extension}]",
+  "examples": [
+    "CLMS_UA_LCU_S2021_V025ha_DK004L3_AALBORG_03035_V01_R00_20240212"
+  ]
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -157,3 +157,25 @@ def test_parsing_fails_without_current(tmp_path, monkeypatch):
         parse_auto("ABC_X.txt")
     assert "current" in str(exc.value)
     schema_registry.clear_cache()
+
+
+def test_parse_urban_atlas_lcu():
+    name = "CLMS_UA_LCU_S2021_V025ha_DK004L3_AALBORG_03035_V01_R00_20240212"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "UA-LCU"
+    assert result.fields == {
+        "prefix": "CLMS",
+        "programme": "UA",
+        "product": "LCU",
+        "survey": "S2021",
+        "resolution": "V025ha",
+        "area_code": "DK004L3",
+        "city": "AALBORG",
+        "tile": "03035",
+        "version": "V01",
+        "release": "R00",
+        "production_date": "20240212",
+        "extension": None,
+    }


### PR DESCRIPTION
## Summary
- add a JSON filename schema for the Copernicus Urban Atlas land cover/land use product, including all field constraints and an example
- cover the new schema with a parser round-trip test to ensure fields are extracted as expected

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dc019410248327a03ba7ba58843d30