### PR TITLE
Rename Sentinel-2 schema sensor field to instrument

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ from parseo import assemble, assemble_auto
 
 fields = {
     "platform": "S2B",
-    "sensor": "MSI",
+    "instrument": "MSI",
     "processing_level": "L2A",
     "sensing_datetime": "20241123T224759",
     "processing_baseline": "N0511",
@@ -244,15 +244,15 @@ GFSC                 0.0.0   current ...\src\parseo\schemas\copernicus\clms\hr-w
 parseo schema-info S2
 # -> {
 #      "schema_id": "copernicus:sentinel:s2",
-#      "description": "Sentinel-2 product filename (MSI sensor, processing levels L1C/L2A; extension optional).",
-#      "template": "{platform}_{sensor}{processing_level}_{sensing_datetime}_..._[.{extension}]",
+#      "description": "Sentinel-2 product filename (MSI instrument, processing levels L1C/L2A; extension optional).",
+#      "template": "{platform}_{instrument}{processing_level}_{sensing_datetime}_..._[.{extension}]",
 #      "examples": [
 #        "S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE",
 #        "..."
 #      ],
 #      "fields": {
 #        "platform": {"type": "string", "enum": ["S2A", "S2B", "S2C"], "description": "Spacecraft unit"},
-#        "sensor": {"type": "string", "enum": ["MSI"], "description": "Sensor"},
+#        "instrument": {"type": "string", "enum": ["MSI"], "description": "Instrument"},
 #        ...
 #      }
 #    }
@@ -264,7 +264,7 @@ Use the CLI to assemble filenames.
 # The CLI auto-selects a schema based on the first compulsory field.
 
 # Example: Sentinel-2 SAFE (first field: platform)
-parseo assemble platform=S2B sensor=MSI processing_level=L2A sensing_datetime=20241123T224759 processing_baseline=N0511 relative_orbit=R101 mgrs_tile=T03VUL generation_datetime=20241123T230829 extension=SAFE
+parseo assemble platform=S2B instrument=MSI processing_level=L2A sensing_datetime=20241123T224759 processing_baseline=N0511 relative_orbit=R101 mgrs_tile=T03VUL generation_datetime=20241123T230829 extension=SAFE
 # -> S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE
 
 # Example: CLMS HR-WSI product (first field: prefix)

--- a/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
@@ -5,17 +5,17 @@
   "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo", "mgrs"],
-  "description": "Sentinel-2 product filename (MSI sensor, processing levels L1C/L2A; extension optional).",
+  "description": "Sentinel-2 product filename (MSI instrument, processing levels L1C/L2A; extension optional).",
   "fields": {
     "platform": {
       "type": "string",
       "enum": ["S2A", "S2B", "S2C"],
       "description": "Spacecraft unit"
     },
-    "sensor": {
+    "instrument": {
       "type": "string",
       "enum": ["MSI"],
-      "description": "Sensor"
+      "description": "Instrument"
     },
     "processing_level": {
       "type": "string",
@@ -53,7 +53,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{platform}_{sensor}{processing_level}_{sensing_datetime}_{processing_baseline}_{relative_orbit}_{mgrs_tile}_{generation_datetime}[.{extension}]",
+  "template": "{platform}_{instrument}{processing_level}_{sensing_datetime}_{processing_baseline}_{relative_orbit}_{mgrs_tile}_{generation_datetime}[.{extension}]",
   "examples": [
     "S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE",
     "S2A_MSIL1C_20230715T103021_N0400_R052_T32TNS_20230715T103555",

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -72,7 +72,7 @@ def test_list_schema_versions():
 def test_assemble_with_family_s2():
     fields = {
         "platform": "S2B",
-        "sensor": "MSI",
+        "instrument": "MSI",
         "processing_level": "L2A",
         "sensing_datetime": "20241123T224759",
         "processing_baseline": "N0511",


### PR DESCRIPTION
## Summary
- rename the Sentinel-2 schema field from `sensor` to `instrument` and update its description and template placeholder
- update README usage examples and assembler tests to reference the new `instrument` field
- ensure formatting via ruff and verify assembler/parser tests continue to pass

## Testing
- `ruff check .`
- `pytest tests/test_assembler.py tests/test_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68df8c133f608327833dd59d07bc1b96