### PR TITLE
Add Landsat STAC mapping and round-trip tests

### DIFF
--- a/src/parseo/schemas/usgs/landsat/landsat_filename_v1_0_0.json
+++ b/src/parseo/schemas/usgs/landsat/landsat_filename_v1_0_0.json
@@ -7,33 +7,30 @@
   "stac_extensions": ["processing", "sat", "eo"],
   "description": "Landsat Collection 2 scene identifier (extension optional).",
   "fields": {
-    "mission_code": {
+    "platform": {
       "type": "string",
-      "enum": ["LT04", "LT05", "LE07", "LC08", "LC09"],
+      "pattern": "^(LT04|LT05|LE07|LC08|LC09)$",
       "description": "Platform and sensor code",
       "stac_map": {
-        "preserve_original_as": "mission_code",
-        "values": {
-          "LT04": {
-            "platform": "landsat-4",
-            "instrument": "TM"
-          },
-          "LT05": {
-            "platform": "landsat-5",
-            "instrument": "TM"
-          },
-          "LE07": {
-            "platform": "landsat-7",
-            "instrument": "ETM+"
-          },
-          "LC08": {
-            "platform": "landsat-8",
-            "instrument": "OLI_TIRS"
-          },
-          "LC09": {
-            "platform": "landsat-9",
-            "instrument": "OLI_TIRS"
-          }
+        "LT04": {
+          "platform": "landsat-4",
+          "instrument": "TM"
+        },
+        "LT05": {
+          "platform": "landsat-5",
+          "instrument": "TM"
+        },
+        "LE07": {
+          "platform": "landsat-7",
+          "instrument": "ETM+"
+        },
+        "LC08": {
+          "platform": "landsat-8",
+          "instrument": "OLI_TIRS"
+        },
+        "LC09": {
+          "platform": "landsat-9",
+          "instrument": "OLI_TIRS"
         }
       }
     },
@@ -46,7 +43,7 @@
     "tier": {"type": "string", "enum": ["T1", "T2", "RT"], "description": "Tier classification"},
     "extension": {"type": "string", "pattern": "^[A-Za-z0-9]+$", "description": "File extension without leading dot"}
   },
-  "template": "{mission_code}_{processing_level}_{wrs_path}{wrs_row}_{acq_date}_{proc_date}_{collection_number}_{tier}[.{extension}]",
+  "template": "{platform}_{processing_level}_{wrs_path}{wrs_row}_{acq_date}_{proc_date}_{collection_number}_{tier}[.{extension}]",
   "examples": [
     "LC08_L1TP_190026_20200101_20200114_02_T1.tar"
   ]

--- a/src/parseo/schemas/usgs/landsat/landsat_filename_v1_0_0.json
+++ b/src/parseo/schemas/usgs/landsat/landsat_filename_v1_0_0.json
@@ -7,7 +7,36 @@
   "stac_extensions": ["processing", "sat", "eo"],
   "description": "Landsat Collection 2 scene identifier (extension optional).",
   "fields": {
-    "mission_code": {"type": "string", "enum": ["LT04", "LT05", "LE07", "LC08", "LC09"], "description": "Platform and sensor code"},
+    "mission_code": {
+      "type": "string",
+      "enum": ["LT04", "LT05", "LE07", "LC08", "LC09"],
+      "description": "Platform and sensor code",
+      "stac_map": {
+        "preserve_original_as": "mission_code",
+        "values": {
+          "LT04": {
+            "platform": "landsat-4",
+            "instrument": "TM"
+          },
+          "LT05": {
+            "platform": "landsat-5",
+            "instrument": "TM"
+          },
+          "LE07": {
+            "platform": "landsat-7",
+            "instrument": "ETM+"
+          },
+          "LC08": {
+            "platform": "landsat-8",
+            "instrument": "OLI_TIRS"
+          },
+          "LC09": {
+            "platform": "landsat-9",
+            "instrument": "OLI_TIRS"
+          }
+        }
+      }
+    },
     "processing_level": {"type": "string", "enum": ["L1TP", "L1GT", "L1GS", "L2SP", "L2SR"], "description": "Processing level"},
     "wrs_path": {"type": "string", "pattern": "^\\d{3}$", "description": "WRS-2 path"},
     "wrs_row": {"type": "string", "pattern": "^\\d{3}$", "description": "WRS-2 row"},

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -108,3 +108,25 @@ def test_assemble_modis_from_stac_fields():
     assembled = assemble(fields, schema_path=schema)
     assert assembled == "MOD09GA.A2021123.h18v04.006.2021132234506.hdf"
 
+
+def test_assemble_landsat_from_stac_fields():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/usgs/landsat/landsat_filename_v1_0_0.json"
+    )
+    fields = {
+        "platform": "landsat-8",
+        "instrument": "OLI_TIRS",
+        "processing_level": "L1TP",
+        "wrs_path": "190",
+        "wrs_row": "026",
+        "acq_date": "20200101",
+        "proc_date": "20200114",
+        "collection_number": "02",
+        "tier": "T1",
+        "extension": "tar",
+    }
+
+    assembled = assemble(fields, schema_path=schema)
+    assert assembled == "LC08_L1TP_190026_20200101_20200114_02_T1.tar"
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -191,3 +191,14 @@ def test_parse_modis_stac_mapping():
     assert result.fields["instrument"] == "MODIS"
     assert result.fields["platform_code"] == "MOD"
     assert result.fields["product"] == "09"
+
+
+def test_parse_landsat_stac_mapping():
+    name = "LC08_L1TP_190026_20200101_20200114_02_T1.tar"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "LANDSAT"
+    assert result.fields["mission_code"] == "LC08"
+    assert result.fields["platform"] == "landsat-8"
+    assert result.fields["instrument"] == "OLI_TIRS"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -199,6 +199,6 @@ def test_parse_landsat_stac_mapping():
 
     assert result.valid
     assert result.match_family == "LANDSAT"
-    assert result.fields["mission_code"] == "LC08"
     assert result.fields["platform"] == "landsat-8"
     assert result.fields["instrument"] == "OLI_TIRS"
+    assert result.fields["platform_code"] == "LC08"


### PR DESCRIPTION
## Summary
- add a STAC mapping for Landsat mission codes with platform and instrument targets
- extend parser tests to cover Landsat identifiers and verify mapped values
- add assembler coverage to round-trip Landsat STAC fields back to mission codes

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfe84d77ec83279a43bbc2c02a86d5