### PR TITLE
Support change intervals in CLC+ raster schema

### DIFF
--- a/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_ras_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_ras_filename_v0_0_1.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:clcplus:ras",
+  "schema_version": "0.0.1",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS CLC+ raster product filename (extension optional).",
+  "fields": {
+    "programme": {
+      "type": "string",
+      "enum": ["CLMS"],
+      "description": "Copernicus Land Monitoring Service programme identifier"
+    },
+    "product": {
+      "type": "string",
+      "enum": ["CLCPLUS"],
+      "description": "Product family identifier"
+    },
+    "data_class": {
+      "type": "string",
+      "enum": ["RAS"],
+      "description": "Data class code (raster)"
+    },
+    "season": {
+      "type": "string",
+      "pattern": "^(S\\d{4}|C\\d{4}-\\d{4})$",
+      "description": "Reference season and year (SYYYY) or change interval (CYYYY-YYYY)"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^R\\d{2}m$",
+      "description": "Spatial resolution expressed with leading 'R' and units"
+    },
+    "tile": {
+      "type": "string",
+      "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
+      "description": "Tile identifier in the EEA 10m grid (easting/northing)"
+    },
+    "product_code": {
+      "type": "string",
+      "pattern": "^\\d{5}$",
+      "description": "EPSG code of the product grid"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{2}$",
+      "description": "Product version"
+    },
+    "revision": {
+      "type": "string",
+      "pattern": "^R\\d{2}$",
+      "description": "Product revision"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["tif"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{programme}_{product}_{data_class}_{season}_{resolution}_{tile}_{product_code}_{version}_{revision}[.{extension}]",
+  "examples": [
+    "CLMS_CLCPLUS_RAS_S2023_R10m_E48N37_03035_V01_R00.tif"
+  ]
+}


### PR DESCRIPTION
## Summary
- allow the season field to accept both status and change tokens (SYYYY, CYYYY-YYYY)
- document that the product code token carries the EPSG identifier

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfef99da9c83278a845d3481bc7a33