### PR TITLE
Add CLMS EGMS L3 velocity grid filename schema

### DIFF
--- a/src/parseo/schemas/copernicus/clms/egms/egms_l3_velocity_grid_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/egms/egms_l3_velocity_grid_filename_v0_0_0.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:egms-l3",
+  "schema_version": "0.0.0",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster"],
+  "description": "Copernicus European Ground Motion Service Level 3 velocity grid filename (extension optional).",
+  "fields": {
+    "prefix": {
+      "type": "string",
+      "enum": ["EGMS"],
+      "description": "Constant service prefix"
+    },
+    "level": {
+      "type": "string",
+      "pattern": "^L[0-9]+$",
+      "description": "Product processing level"
+    },
+    "tile": {
+      "type": "string",
+      "pattern": "^E\\d{2,3}N\\d{2,3}$",
+      "description": "EGMS 100 km grid tile identifier"
+    },
+    "tile_size": {
+      "type": "string",
+      "pattern": "^\\d{2,3}km$",
+      "description": "Spatial tile size"
+    },
+    "component": {
+      "type": "string",
+      "pattern": "^(?:E|N|U)$",
+      "description": "Displacement component (east, north or up)"
+    },
+    "start_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Start year of the velocity estimation period"
+    },
+    "end_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "End year of the velocity estimation period"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["tif", "tiff"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{prefix}_{level}_{tile}_{tile_size}_{component}_{start_year}_{end_year}_{version}[.{extension}]",
+  "examples": [
+    "EGMS_L3_E28N49_100km_U_2018_2022_1.tiff",
+    "EGMS_L3_E37N28_100km_U_2019_2023_1.tiff"
+  ]
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -181,6 +181,25 @@ def test_parse_urban_atlas_lcu():
     }
 
 
+def test_parse_clms_egms_l3_velocity_grid():
+    name = "EGMS_L3_E28N49_100km_U_2018_2022_1.tiff"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "EGMS-L3"
+    assert result.fields == {
+        "prefix": "EGMS",
+        "level": "L3",
+        "tile": "E28N49",
+        "tile_size": "100km",
+        "component": "U",
+        "start_year": "2018",
+        "end_year": "2022",
+        "version": "1",
+        "extension": "tiff",
+    }
+
+
 def test_parse_modis_stac_mapping():
     name = "MOD09GA.A2021123.h18v04.006.2021132234506.hdf"
     result = parse_auto(name)


### PR DESCRIPTION
## Summary
- add a schema for Copernicus EGMS Level 3 velocity grid filenames, including component, temporal range, and tile fields
- ensure the parser recognises EGMS products via a dedicated regression test

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dff06a5624832794e8c527fb7e7d96