### PR TITLE
Clarify NVLCC schema fields

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hrl/non-vegetated-land-cover-characteristics/non-vegetated-land-cover-characteristics_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/non-vegetated-land-cover-characteristics/non-vegetated-land-cover-characteristics_filename_v0_0_0.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:hrl:nvlcc",
+  "schema_version": "0.0.0",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS High Resolution Layer Non-Vegetated Land Cover Characteristics product filename (extension optional).",
+  "fields": {
+    "prefix": {
+      "type": "string",
+      "enum": ["CLMS"],
+      "description": "Constant program prefix"
+    },
+    "theme": {
+      "type": "string",
+      "enum": ["HRLNVLCC"],
+      "description": "High Resolution Layer theme identifier"
+    },
+    "layer": {
+      "type": "string",
+      "pattern": "^[A-Z]{3,5}$",
+      "description": "Layer code (e.g., IMCCS, IMDC, SBCC)"
+    },
+    "temporal_coverage": {
+      "type": "string",
+      "pattern": "^(?:C\\d{4}-\\d{4}|S\\d{4})$",
+      "description": "Temporal coverage token where CYYYY-YYYY captures change layers and SYYYY captures status layers"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^R\\d{2,3}m$",
+      "description": "Spatial resolution"
+    },
+    "tile": {
+      "type": "string",
+      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+      "description": "EEA reference grid tile identifier"
+    },
+    "epsg_code": {
+      "type": "string",
+      "pattern": "^\\d{5}$",
+      "description": "EPSG code padded to five digits"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{2}$",
+      "description": "Product version"
+    },
+    "release": {
+      "type": "string",
+      "pattern": "^R\\d{2}$",
+      "description": "Release identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["tif"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{prefix}_{theme}_{layer}_{temporal_coverage}_{resolution}_{tile}_{epsg_code}_{version}_{release}[.{extension}]",
+  "examples": [
+    "CLMS_HRLNVLCC_IMCCS_C2018-2021_R20m_E09N27_03035_V01_R01.tif",
+    "CLMS_HRLNVLCC_IMD_S2021_R10m_E09N27_03035_V01_R01.tif",
+    "CLMS_HRLNVLCC_IBUC_C2018-2021_R20m_E37N28_03035_V01_R02.tif",
+    "CLMS_HRLNVLCC_SBCC_C2018-2021_R100m_E37N28_03035_V01_R02.tif"
+  ]
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -181,6 +181,26 @@ def test_parse_urban_atlas_lcu():
     }
 
 
+def test_parse_clms_hrl_nvlcc():
+    name = "CLMS_HRLNVLCC_IMD_S2021_R10m_E09N27_03035_V01_R01.tif"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "NVLCC"
+    assert result.fields == {
+        "prefix": "CLMS",
+        "theme": "HRLNVLCC",
+        "layer": "IMD",
+        "temporal_coverage": "S2021",
+        "resolution": "R10m",
+        "tile": "E09N27",
+        "epsg_code": "03035",
+        "version": "V01",
+        "release": "R01",
+        "extension": "tif",
+    }
+
+
 def test_parse_modis_stac_mapping():
     name = "MOD09GA.A2021123.h18v04.006.2021132234506.hdf"
     result = parse_auto(name)


### PR DESCRIPTION
## Summary
- clarify the NVLCC filename schema by using consistent program wording, detailing temporal coverage tokens, and mapping tile and EPSG components to the correct fields
- update the parser test expectations to reflect the revised tile and EPSG field names

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dff03aeb7083279be40f5cf30b4bd7