### PR TITLE
Allow new CLMS WSI FSC and GFSC file identifiers

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hr-wsi/fsc/fsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/fsc/fsc_filename_v0_0_0.json
@@ -14,7 +14,20 @@
     "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
     "platform": {"type": "string", "enum": ["S2A", "S2B"], "description": "Satellite platform"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "file_id": {"type": "string", "enum": ["FSCOG", "FSCOG-QA", "QAFLAGS", "CLD", "NDSI", "MTD"], "description": "File identifier"},
+    "file_id": {
+      "type": "string",
+      "enum": [
+        "CLD",
+        "FSCOG",
+        "FSCOG-QA",
+        "FSCTOC",
+        "FSCTOC-QA",
+        "MTD",
+        "NDSI",
+        "QAFLAGS"
+      ],
+      "description": "File identifier"
+    },
     "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
   },
   "template": "{prefix}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{file_id}[.{extension}]",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc/gfsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc/gfsc_filename_v0_0_0.json
@@ -14,7 +14,11 @@
     "period": {"type": "string", "pattern": "^\\d{8}P7D$", "description": "Aggregation period"},
     "combination": {"type": "string", "enum": ["COMB"], "description": "Combination method"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "file_id": {"type": "string", "enum": ["GF", "GF-QA", "QAFLAGS", "MTD"], "description": "File identifier"},
+    "file_id": {
+      "type": "string",
+      "enum": ["AT", "GF", "GF-QA", "MTD", "QAFLAGS"],
+      "description": "File identifier"
+    },
     "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
   },
   "template": "{prefix}_{product}_{pixel_spacing}_{mgrs_tile}_{period}_{combination}_{version}_{file_id}[.{extension}]",


### PR DESCRIPTION
## Summary
- add the FSCTOC and FSCTOC-QA file identifiers to the HR-WSI FSC schema
- include the AT file identifier in the HR-WSI GFSC schema

## Testing
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dff4872860832784adfa296fc45e65