### PR TITLE
Add schema v0.0.1 for CLMS Small Woody Features EPSG filenames

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_0.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hrl:small-woody-features",
   "schema_version": "0.0.0",
-  "status": "current",
+  "status": "deprecated",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS High Resolution Layer Small Woody Features product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:hrl:small-woody-features",
+  "schema_version": "0.0.1",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS High Resolution Layer Small Woody Features product filename (extension optional).",
+  "fields": {
+    "product": {
+      "type": "string",
+      "enum": ["SWF"],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(?:005m|010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "tile_id": {
+      "type": "string",
+      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+      "description": "EEA reference grid tile identifier"
+    },
+    "epsg_code": {
+      "type": "string",
+      "pattern": "^\\d{5}$",
+      "description": "EPSG code padded to five digits"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["tif"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{product}_{reference_year}_{resolution}_{tile_id}_{epsg_code}[.{extension}]",
+  "examples": [
+    "SWF_2018_005m_E34N27_03035.tif",
+    "SWF_2018_005m_E36N31_03035.tif"
+  ]
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -201,6 +201,22 @@ def test_parse_clms_hrl_nvlcc():
         "extension": "tif",
     }
 
+
+def test_parse_clms_hrl_small_woody_features():
+    name = "SWF_2018_005m_E34N27_03035.tif"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "SMALL-WOODY-FEATURES"
+    assert result.fields == {
+        "product": "SWF",
+        "reference_year": "2018",
+        "resolution": "005m",
+        "tile_id": "E34N27",
+        "epsg_code": "03035",
+        "extension": "tif",
+    }
+
 def test_parse_clms_egms_l3_velocity_grid():
     name = "EGMS_L3_E28N49_100km_U_2018_2022_1.tiff"
     result = parse_auto(name)


### PR DESCRIPTION
## Summary
- mark the legacy CLMS HRL Small Woody Features filename schema as deprecated
- add schema version 0.0.1 to support EPSG-coded SWF filenames and examples
- cover the new filenames with a parser regression test

## Testing
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dff4b9eba08327bc0e4f249e3d4c6d