### PR TITLE
Allow VLCC schema change tokens to include year ranges

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hrl/vegetated-land-cover-characteristics/vegetated-land-cover-characteristics_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/vegetated-land-cover-characteristics/vegetated-land-cover-characteristics_filename_v0_0_0.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:hrl:vlcc",
+  "schema_version": "0.0.0",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS High Resolution Layer Vegetated Land Cover Characteristics product filename (extension optional).",
+  "fields": {
+    "prefix": {
+      "type": "string",
+      "enum": ["CLMS"],
+      "description": "Constant program prefix"
+    },
+    "theme": {
+      "type": "string",
+      "enum": ["HRLVLCC"],
+      "description": "High Resolution Layer theme identifier"
+    },
+    "layer": {
+      "type": "string",
+      "pattern": "^[A-Z0-9]{3,6}$",
+      "description": "Layer code (e.g., GRAMD1, DLT, CPSCT)"
+    },
+    "temporal_coverage": {
+      "type": "string",
+      "pattern": "^(?:C\\d{4}(?:-\\d{4})?|S\\d{4})$",
+      "description": "Temporal coverage token where CYYYY or CYYYY-YYYY captures change layers and SYYYY captures status layers"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^R\\d{2,3}m$",
+      "description": "Spatial resolution"
+    },
+    "tile": {
+      "type": "string",
+      "pattern": "^(?:[EW]\\d{2,3}[NS]\\d{2,3}|[A-Z]{2})$",
+      "description": "EEA reference grid tile identifier or two-letter geographic code"
+    },
+    "epsg_code": {
+      "type": "string",
+      "pattern": "^\\d{5}$",
+      "description": "EPSG code padded to five digits"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(?:V\\d{2}|NEW)$",
+      "description": "Product version or NEW placeholder for provisional releases"
+    },
+    "release": {
+      "type": "string",
+      "pattern": "^R\\d{2}$",
+      "description": "Release identifier (optional when absent in source filenames)"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["tif", "tiff"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{prefix}_{theme}_{layer}_{temporal_coverage}_{resolution}_{tile}_{epsg_code}_{version}[_{release}][.{extension}]",
+  "examples": [
+    "CLMS_HRLVLCC_GRA_S2021_R10m_E27N48_03035_V01_R00.tif",
+    "CLMS_HRLVLCC_CTY_S2021_R10m_E48N41_03035_V01_R00.tif",
+    "CLMS_HRLVLCC_GRAMD1_S2017_R10m_E28N20_03035_V02_R00.tif",
+    "CLMS_HRLVLCC_GRAMD1_S2019_R10m_GF_32622_V01_R00.tif",
+    "CLMS_HRLVLCC_GRAMD4_S2021_R10m_RE_32740_V01_R00.tif",
+    "CLMS_HRLVLCC_GRAME_S2020_R10m_E49N44_03035_V02_R00.tif",
+    "CLMS_HRLVLCC_DLT_S2022_R10m_E17N09_03035_V01_R00.tif",
+    "CLMS_HRLVLCC_CPSCT_S2021_R10m_E39N23_03035_NEW.tiff"
+  ]
+}


### PR DESCRIPTION
## Summary
- broaden the vegetated land cover schema's temporal_coverage pattern so change tokens accept both CYYYY and CYYYY-YYYY formats
- clarify the field description to mention both supported change token patterns

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dff3cccb2883279fe5c28c9e6f295f