### PR TITLE
Update README STAC mapping example

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,12 +382,22 @@ Adding support for a new product requires only a JSON schema placed under `src/p
     -   Example:
 
         ``` jsonc
-        "collection": {
+        "prefix": {
           "type": "string",
-          "enum": ["MOD09GA", "MYD09GA"],
+          "pattern": "^(MOD|MYD|MCD)$",
           "stac_map": {
-            "MOD09GA": {"collection": "mod09ga"},
-            "MYD09GA": {"collection": "myd09ga"}
+            "MOD": {
+              "platform": "Terra",
+              "instrument": "MODIS"
+            },
+            "MYD": {
+              "platform": "Aqua",
+              "instrument": "MODIS"
+            },
+            "MCD": {
+              "platform": "Combined",
+              "instrument": "MODIS"
+            }
           }
         },
         "tile": {


### PR DESCRIPTION
## Summary
- replace the README `stac_map` example with the template mapping for MOD, MYD, and MCD prefixes

## Testing
- `ruff check .`
- `pytest` *(fails: FileNotFoundError for expected schema fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c065c16c83278fa008d8db42850b