### PR TITLE
Include Sentinel-C platforms in CLMS HR-WSI schemas

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
@@ -12,7 +12,7 @@
     "pixel_spacing": {"type": "string", "enum": ["020m"], "description": "Pixel spacing"},
     "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
     "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S2A", "S2B"], "description": "Satellite platform"},
+    "platform": {"type": "string", "enum": ["S2A", "S2B", "S2C"], "description": "Satellite platform"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "file_id": {"type": "string", "enum": ["CC", "CC-QA", "QAFLAGS", "MTD"], "description": "File identifier"},
     "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
@@ -12,7 +12,7 @@
     "pixel_spacing": {"type": "string", "enum": ["020m"], "description": "Pixel spacing"},
     "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
     "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S2A", "S2B"], "description": "Satellite platform"},
+    "platform": {"type": "string", "enum": ["S2A", "S2B", "S2C"], "description": "Satellite platform"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "file_id": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
@@ -12,7 +12,7 @@
     "pixel_spacing": {"type": "string", "enum": ["060m"], "description": "Pixel spacing"},
     "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
     "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S1A", "S1B"], "description": "Satellite platform"},
+    "platform": {"type": "string", "enum": ["S1A", "S1B", "S1C"], "description": "Satellite platform"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "file_id": {"type": "string", "enum": ["WSM", "WSM-QA", "MTD"], "description": "File identifier"},
     "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
@@ -12,7 +12,7 @@
     "pixel_spacing": {"type": "string", "enum": ["060m"], "description": "Pixel spacing"},
     "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
     "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S1A", "S1B"], "description": "Satellite platform"},
+    "platform": {"type": "string", "enum": ["S1A", "S1B", "S1C"], "description": "Satellite platform"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "file_id": {"type": "string", "enum": ["SSC", "SSC-QA", "MTD"], "description": "File identifier"},
     "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
@@ -12,7 +12,7 @@
     "pixel_spacing": {"type": "string", "enum": ["020m", "060m"], "description": "Pixel spacing"},
     "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
     "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S1A", "S1B", "S2A", "S2B"], "description": "Satellite platform"},
+    "platform": {"type": "string", "enum": ["S1A", "S1B", "S1C", "S2A", "S2B", "S2C"], "description": "Satellite platform"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "file_id": {"type": "string", "enum": ["WIC", "PRB", "QAFLAGS", "WIC-QA", "MTD"], "description": "File identifier"},
     "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}


### PR DESCRIPTION
## Summary
- add Sentinel-1C and Sentinel-2C platform codes to the CLMS HR-WSI filename schemas to reflect available spacecraft

## Testing
- `ruff check .`
- `pytest` *(fails: FileNotFoundError for expected schema paths that are outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e75ccd6c8327b4f4ef6ba946820c