### PR TITLE
Add STAC extensions to MODIS schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ print(res.fields["product"])   # 09
 print(res.fields["variant"])   # GA
 ```
 
+This schema advertises the Processing, Sat, Raster, and Electro-Optical STAC
+extensions so MODIS filenames can be associated with the corresponding STAC
+metadata (`processing`, `sat`, `raster`, `eo`).
+
 ### Assembling a filename
 
 ``` python

--- a/src/parseo/schemas/nasa/modis_filename_v1_0_0.json
+++ b/src/parseo/schemas/nasa/modis_filename_v1_0_0.json
@@ -4,6 +4,7 @@
   "schema_version": "1.0.0",
   "status": "current",
   "stac_version": "1.1.0",
+  "stac_extensions": ["processing", "sat", "raster", "eo"],
   "description": "MODIS product filename (extension optional).",
   "fields": {
     "platform": {


### PR DESCRIPTION
## Summary
- add the Processing, Sat, Raster, and EO STAC extensions to the MODIS filename schema
- document the MODIS schema's STAC extension coverage in the README example

## Testing
- PYTHONPATH=src python - <<'PY'
from parseo import validate_schema
validate_schema("src/parseo/schemas/nasa/modis_filename_v1_0_0.json")
PY

------
https://chatgpt.com/codex/tasks/task_e_68e1087ed8c883279f420045814a2058