### PR TITLE
Normalize STAC extension identifiers in schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Adding support for a new product requires only a JSON schema placed under `src/p
 2.  **Write the versioned schema file**
     -   Filename: `<product>_filename_vX_Y_Z.json`
     -   Include top-level metadata such as **required** `schema_id` and `schema_version` (needed for discovery), `status` (`current`, `deprecated`, etc.), `stac_version`, optional `stac_extensions`, and a short `description`. ParsEO will use the version flagged as current as a default when assembling a filename.
+    -   When populating `stac_extensions`, always list the canonical schema URIs published at [stac-extensions.github.io](https://stac-extensions.github.io) (for example, `https://stac-extensions.github.io/eo/v1.0.0/schema.json`).
 3.  **Define fields inline**
     -   Add a top-level `"fields"` object. Each field uses JSON Schema keywords like `type`, `pattern` or `enum`, plus an optional `description`.
     -   Mark required fields in a top-level `"required"` array. Any field not listed there is optional.

--- a/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "Corine Land Cover product filename (extension optional).",
   "fields": {
     "project": {

--- a/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_ras_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_ras_filename_v0_0_1.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.1",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS CLC+ raster product filename (extension optional).",
   "fields": {
     "programme": {

--- a/src/parseo/schemas/copernicus/clms/egms/egms_l3_velocity_grid_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/egms/egms_l3_velocity_grid_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json"],
   "description": "Copernicus European Ground Motion Service Level 3 velocity grid filename (extension optional).",
   "fields": {
     "prefix": {

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-VPP Seasonal Trajectories Plant Phenology Index product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["ST"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vegetation_index_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vegetation_index_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-VPP Vegetation Indices (FAPAR, LAI, NDVI, PPI, FCOVER, DMP) product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_VPP"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-WSI Cloud Cover product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-WSI Fractional Snow Cover product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-WSI Gap-filled Fractional Snow Cover product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/icd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/icd_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-WSI Ice Cover Duration product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_comb_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-WSI Snow Products combination filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_s2_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_s2_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-WSI Snow Products Sentinel-2 source filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-WSI Small Water Surface product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-WSI Water Detection and Surface Displacement product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-WSI Water and Ice Cover combination filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS HR-WSI Water and Ice Cover Sentinel-1 and Sentinel-2 product filename (extension optional).",
   "fields": {
     "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},

--- a/src/parseo/schemas/copernicus/clms/hrl/forest-type_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/forest-type_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS High Resolution Layer Forest Type product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["FTY"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hrl/grassland_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/grassland_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS High Resolution Layer Grassland product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["GRA"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hrl/impervious-built-up-area_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/impervious-built-up-area_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS High Resolution Layer Impervious Built-up Area product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["IBU"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hrl/imperviousness_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imperviousness_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS High Resolution Layer Imperviousness product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["IMD"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hrl/non-vegetated-land-cover-characteristics_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/non-vegetated-land-cover-characteristics_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS High Resolution Layer Non-Vegetated Land Cover Characteristics product filename (extension optional).",
   "fields": {
     "prefix": {

--- a/src/parseo/schemas/copernicus/clms/hrl/small-woody-features_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/small-woody-features_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "deprecated",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS High Resolution Layer Small Woody Features product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["SWF"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hrl/small-woody-features_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/small-woody-features_filename_v0_0_1.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.1",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS High Resolution Layer Small Woody Features product filename (extension optional).",
   "fields": {
     "product": {

--- a/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS High Resolution Layer Tree Cover Density product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["TCD"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/hrl/vegetated-land-cover-characteristics_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/vegetated-land-cover-characteristics_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS High Resolution Layer Vegetated Land Cover Characteristics product filename (extension optional).",
   "fields": {
     "prefix": {

--- a/src/parseo/schemas/copernicus/clms/hrl/water-wetness_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/water-wetness_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "CLMS High Resolution Layer Water & Wetness product filename (extension optional).",
   "fields": {
     "product": {"type": "string", "enum": ["WAW"], "description": "Product code"},

--- a/src/parseo/schemas/copernicus/clms/urban-atlas/urban_atlas_dhm_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/urban-atlas/urban_atlas_dhm_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["vector"],
+  "stac_extensions": ["https://stac-extensions.github.io/vector/v1.0.0/schema.json"],
   "description": "Copernicus Urban Atlas 2021 Digital Height Model (DHM) vector filename schema.",
   "fields": {
     "area_code": {

--- a/src/parseo/schemas/copernicus/clms/urban-atlas/urban_atlas_lcu_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/urban-atlas/urban_atlas_lcu_filename_v0_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["vector", "raster"],
+  "stac_extensions": ["https://stac-extensions.github.io/vector/v1.0.0/schema.json", "https://stac-extensions.github.io/raster/v1.0.0/schema.json"],
   "description": "Copernicus Urban Atlas filename schema covering status and change layers (extension optional).",
   "fields": {
     "prefix": {

--- a/src/parseo/schemas/copernicus/sentinel/s1_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s1_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["processing", "sat", "sar"],
+  "stac_extensions": ["https://stac-extensions.github.io/processing/v1.0.0/schema.json", "https://stac-extensions.github.io/sat/v1.0.0/schema.json", "https://stac-extensions.github.io/sar/v1.0.0/schema.json"],
   "description": "Sentinel-1 product filename; TTTR token is RAW_, SLC_, OCN_, or GRD(F|H|M|E); extension optional.",
   "fields": {
     "platform": {

--- a/src/parseo/schemas/copernicus/sentinel/s2_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s2_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["processing", "sat", "raster", "eo", "mgrs"],
+  "stac_extensions": ["https://stac-extensions.github.io/processing/v1.0.0/schema.json", "https://stac-extensions.github.io/sat/v1.0.0/schema.json", "https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json", "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json"],
   "description": "Sentinel-2 product filename (MSI instrument, processing levels L1C/L2A; extension optional).",
   "fields": {
     "platform": {

--- a/src/parseo/schemas/copernicus/sentinel/s3_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s3_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["processing", "sat", "raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/processing/v1.0.0/schema.json", "https://stac-extensions.github.io/sat/v1.0.0/schema.json", "https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "Sentinel-3 product filename (OLCI/SLSTR/SRAL; optional relative orbit, segment, extension).",
   "fields": {
     "platform": {"type": "string", "enum": ["S3A", "S3B", "S3C"], "description": "Spacecraft unit (platform)"},

--- a/src/parseo/schemas/copernicus/sentinel/s4_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s4_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["processing", "sat", "raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/processing/v1.0.0/schema.json", "https://stac-extensions.github.io/sat/v1.0.0/schema.json", "https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "Sentinel-4 product filename (UVN; optional tile, extension).",
   "fields": {
     "platform": {"type": "string", "enum": ["S4A", "S4B"]},

--- a/src/parseo/schemas/copernicus/sentinel/s5p_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s5p_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["processing", "sat", "raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/processing/v1.0.0/schema.json", "https://stac-extensions.github.io/sat/v1.0.0/schema.json", "https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "Sentinel-5P product filename (TROPOMI; extension optional).",
   "fields": {
     "platform": {"type": "string", "enum": ["S5P"]},

--- a/src/parseo/schemas/copernicus/sentinel/s6_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s6_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["processing", "sat"],
+  "stac_extensions": ["https://stac-extensions.github.io/processing/v1.0.0/schema.json", "https://stac-extensions.github.io/sat/v1.0.0/schema.json"],
   "description": "Sentinel-6 product filename (P4 altimetry; extension optional).",
   "fields": {
     "platform": {"type": "string", "enum": ["S6A", "S6B"]},

--- a/src/parseo/schemas/eumetsat/metop_filename_v1_0_0.json
+++ b/src/parseo/schemas/eumetsat/metop_filename_v1_0_0.json
@@ -6,10 +6,10 @@
   "description": "EUMETSAT Metop product filename (extension optional).",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "processing",
-    "sat",
-    "raster",
-    "eo"
+    "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
   ],
   "fields": {
     "platform": {

--- a/src/parseo/schemas/eumetsat/mtg_filename_v1_0_0.json
+++ b/src/parseo/schemas/eumetsat/mtg_filename_v1_0_0.json
@@ -6,10 +6,10 @@
   "description": "EUMETSAT MTG product filename (extension optional).",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "processing",
-    "sat",
-    "raster",
-    "eo"
+    "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
   ],
   "fields": {
     "platform": {

--- a/src/parseo/schemas/nasa/modis_filename_v1_0_0.json
+++ b/src/parseo/schemas/nasa/modis_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["processing", "sat", "raster", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/processing/v1.0.0/schema.json", "https://stac-extensions.github.io/sat/v1.0.0/schema.json", "https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "MODIS product filename (extension optional).",
   "fields": {
     "platform": {

--- a/src/parseo/schemas/usgs/landsat/landsat_filename_v1_0_0.json
+++ b/src/parseo/schemas/usgs/landsat/landsat_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["processing", "sat", "eo"],
+  "stac_extensions": ["https://stac-extensions.github.io/processing/v1.0.0/schema.json", "https://stac-extensions.github.io/sat/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
   "description": "Landsat Collection 2 scene identifier (extension optional).",
   "fields": {
     "platform": {


### PR DESCRIPTION
## Summary
- replace short-form `stac_extensions` values in all schemas with the canonical STAC extension URIs from stac-extensions.github.io
- document the requirement to use canonical extension URIs when creating new schemas

## Testing
- ruff check .
- pytest *(fails: FileNotFoundError loading schema fixtures referenced by tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e10a289e4883279e385441a16ce1aa