### PR TITLE
Enforce five-digit EPSG codes across HRL schemas

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hrl/impervious-built-up-area_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/impervious-built-up-area_filename_v0_0_0.json
@@ -11,7 +11,7 @@
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
     "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution in metres with leading zeros"},
     "tile": {"type": "string", "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$", "description": "EEA reference grid tile identifier"},
-    "epsg_code": {"type": "string", "pattern": "^\\d{4,5}$", "description": "EPSG code (optionally zero-padded to five digits)"},
+    "epsg_code": {"type": "string", "pattern": "^\\d{5}$", "description": "EPSG code of the product grid"},
     "version": {"type": "string", "pattern": "^v\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },

--- a/src/parseo/schemas/copernicus/clms/hrl/non-vegetated-land-cover-characteristics_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/non-vegetated-land-cover-characteristics_filename_v0_0_0.json
@@ -39,8 +39,8 @@
     },
     "epsg_code": {
       "type": "string",
-      "pattern": "^\\d{4,5}$",
-      "description": "EPSG code (optionally zero-padded to five digits)"
+      "pattern": "^\\d{5}$",
+      "description": "EPSG code of the product grid"
     },
     "version": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/small-woody-features_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/small-woody-features_filename_v0_0_1.json
@@ -29,8 +29,8 @@
     },
     "epsg_code": {
       "type": "string",
-      "pattern": "^\\d{4,5}$",
-      "description": "EPSG code (optionally zero-padded to five digits)"
+      "pattern": "^\\d{5}$",
+      "description": "EPSG code of the product grid"
     },
     "extension": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/vegetated-land-cover-characteristics_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/vegetated-land-cover-characteristics_filename_v0_0_0.json
@@ -39,8 +39,8 @@
     },
     "epsg_code": {
       "type": "string",
-      "pattern": "^\\d{4,5}$",
-      "description": "EPSG code (optionally zero-padded to five digits)"
+      "pattern": "^\\d{5}$",
+      "description": "EPSG code of the product grid"
     },
     "version": {
       "type": "string",


### PR DESCRIPTION
## Summary
- require EPSG codes in Copernicus HRL filename schemas to be five digits
- align EPSG code descriptions with the product grid wording

## Testing
- ruff check .
- pytest *(fails: missing schema fixtures outside repo scope)*

------
https://chatgpt.com/codex/tasks/task_e_68e1108654908327af6325322c82bb79