### PR TITLE
Add EEA tile identifier to CLMS HRL schemas

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
@@ -9,12 +9,12 @@
   "fields": {
     "variable": {"type": "string", "enum": ["FTY"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [
     "FTY_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
@@ -9,12 +9,12 @@
   "fields": {
     "variable": {"type": "string", "enum": ["GRA"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [
     "GRA_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
@@ -9,12 +9,12 @@
   "fields": {
     "variable": {"type": "string", "enum": ["IMD"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{product}_{reference_year}_{tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [
     "IMD_2021_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
@@ -9,12 +9,12 @@
   "fields": {
     "variable": {"type": "string", "enum": ["SWF"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [
     "SWF_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/tcd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tcd_filename_v0_0_0.json
@@ -9,12 +9,12 @@
   "fields": {
     "variable": {"type": "string", "enum": ["TCD"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [
     "TCD_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
@@ -9,12 +9,12 @@
   "fields": {
     "variable": {"type": "string", "enum": ["WAW"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [
     "WAW_2018_E042N018_010m_V100.tif"
   ]

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -90,6 +90,20 @@ def test_assemble_with_family_s2():
     )
 
 
+def test_assemble_clms_hrl_imperviousness():
+    fields = {
+        "variable": "IMD",
+        "reference_year": "2021",
+        "eea_tile": "E042N018",
+        "resolution": "010m",
+        "version": "V100",
+        "extension": "tif",
+    }
+
+    name = assemble(fields, family="IMPERVIOUSNESS")
+    assert name == "IMD_2021_E042N018_010m_V100.tif"
+
+
 def test_assemble_modis_from_stac_fields():
     schema = (
         Path(__file__).resolve().parents[1]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -227,6 +227,22 @@ def test_parse_clms_hrl_small_woody_features():
         "extension": "tif",
     }
 
+
+def test_parse_clms_hrl_imperviousness():
+    name = "IMD_2021_E042N018_010m_V100.tif"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "IMPERVIOUSNESS"
+    assert result.fields == {
+        "variable": "IMD",
+        "reference_year": "2021",
+        "eea_tile": "E042N018",
+        "resolution": "010m",
+        "version": "V100",
+        "extension": "tif",
+    }
+
 def test_parse_clms_egms_l3_velocity_grid():
     name = "EGMS_L3_E28N49_100km_U_2018_2022_1.tiff"
     result = parse_auto(name)


### PR DESCRIPTION
## Summary
- replace the CLMS HRL LAEA tile tokens with the new `eea_tile` field and description
- adjust the imperviousness schema template and extend parser/assembler tests to cover the new token

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e15ca6332c8327bd87270f9b3e1e82