### PR TITLE
Add EGMS filename schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
     -   High Resolution Vegetation Phenology & Productivity (HR-VPP)
     -   High Resolution Water & Snow / Ice (HR-WSI)
     -   High Resolution Layers (HRL)
+-   **Copernicus European Ground Motion Service (EGMS)**:
+    -   L2a Basic & Calibrated products
+    -   L3 Ortho tiles (vertical and east-west components)
+    -   GNSS model product (AEPND)
 
 ## Installation
 

--- a/src/parseo/schemas/copernicus/egms/egms_gnss_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/egms/egms_gnss_filename_v1_0_0.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:egms:egms_gnss",
+  "schema_version": "1.0.0",
+  "status": "current",
+  "description": "European Ground Motion Service (EGMS) GNSS model product filename.",
+  "fields": {
+    "service": {
+      "type": "string",
+      "enum": ["EGMS"],
+      "description": "Service acronym"
+    },
+    "product_code": {
+      "type": "string",
+      "enum": ["AEPND"],
+      "description": "Product identifier"
+    },
+    "issue_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Year of issue"
+    },
+    "revision": {
+      "type": "string",
+      "pattern": "^\\d$",
+      "description": "Revision within the issue year (0 pre-release, 1 first release, etc.)"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["csv"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{service}_{product_code}_V{issue_year}.{revision}[.{extension}]",
+  "examples": [
+    "EGMS_AEPND_V2020.0.csv",
+    "EGMS_AEPND_V2021.1.csv"
+  ]
+}

--- a/src/parseo/schemas/copernicus/egms/egms_l2a_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/egms/egms_l2a_filename_v1_0_0.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:egms:egms_l2a",
+  "schema_version": "1.0.0",
+  "status": "current",
+  "description": "European Ground Motion Service (EGMS) L2a Basic and Calibrated product filename (CSV delivered data, often distributed as ZIP).",
+  "fields": {
+    "service": {
+      "type": "string",
+      "enum": ["EGMS"],
+      "description": "Service acronym"
+    },
+    "product_level": {
+      "type": "string",
+      "enum": ["L2a"],
+      "description": "Product level"
+    },
+    "track_number": {
+      "type": "string",
+      "pattern": "^\\d{3}$",
+      "description": "Relative track number"
+    },
+    "burst_index": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Progressive burst index within the track"
+    },
+    "swath": {
+      "type": "string",
+      "pattern": "^IW[0-9]$",
+      "description": "Sentinel-1 swath identifier"
+    },
+    "polarization": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}$",
+      "description": "Polarisation mode (e.g., VV, VH)"
+    },
+    "start_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "First nominal year of data coverage"
+    },
+    "end_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Last nominal year of data coverage"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+$",
+      "description": "Product release version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["csv", "zip"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{service}_{product_level}_{track_number}_{burst_index}_{swath}_{polarization}_{start_year}_{end_year}_{version}[.{extension}]",
+  "examples": [
+    "EGMS_L2a_088_0282_IW2_VV_2018_2022_1.csv",
+    "EGMS_L2a_088_0282_IW2_VV_2018_2022_1.zip"
+  ]
+}

--- a/src/parseo/schemas/copernicus/egms/egms_l3_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/egms/egms_l3_filename_v1_0_0.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:egms:egms_l3",
+  "schema_version": "1.0.0",
+  "status": "current",
+  "description": "European Ground Motion Service (EGMS) L3 Ortho product tile filename for vertical (U) and east-west (E) velocity components.",
+  "fields": {
+    "service": {
+      "type": "string",
+      "enum": ["EGMS"],
+      "description": "Service acronym"
+    },
+    "product_level": {
+      "type": "string",
+      "enum": ["L3"],
+      "description": "Product level"
+    },
+    "tile_easting": {
+      "type": "string",
+      "pattern": "^\\d{1,3}$",
+      "description": "Easting coordinate of the tile south-west corner (km)"
+    },
+    "tile_northing": {
+      "type": "string",
+      "pattern": "^\\d{1,3}$",
+      "description": "Northing coordinate of the tile south-west corner (km)"
+    },
+    "tile_size": {
+      "type": "string",
+      "enum": ["100km"],
+      "description": "Tile size identifier"
+    },
+    "component": {
+      "type": "string",
+      "enum": ["U", "E"],
+      "description": "Velocity component (U=vertical, E=east-west)"
+    },
+    "start_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "First nominal year of data coverage"
+    },
+    "end_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Last nominal year of data coverage"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+$",
+      "description": "Product release version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["tif", "csv"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{service}_{product_level}_E{tile_easting}N{tile_northing}_{tile_size}_{component}_{start_year}_{end_year}_{version}[.{extension}]",
+  "examples": [
+    "EGMS_L3_E40N28_100km_U_2018_2022_1.tif",
+    "EGMS_L3_E40N28_100km_E_2018_2022_1.tif",
+    "EGMS_L3_E40N28_100km_U_2018_2022_1.csv"
+  ]
+}


### PR DESCRIPTION
## Summary
- add JSON schemas for EGMS L2a Basic/Calibrated, L3 Ortho, and GNSS model filenames
- document European Ground Motion Service coverage in the supported products list

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e16bd2215483278217a79dfe029731