### PR TITLE
Add schemas for EGMS L2A and GNSS filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 -   **EUMETSAT missions**: MTG, Metop
 -   **Copernicus Land Monitoring Service (CLMS)**:
     -   Corine Land Cover (CLC) and CLC+ Raster
-    -   European Ground Motion Service (EGMS) Level 3 velocity grid
+    -   European Ground Motion Service (EGMS) Level 2 basic/calibrated products, Level 3 velocity grid, and GNSS model
     -   Urban Atlas Land Cover / Land Use
     -   High Resolution Vegetation Phenology & Productivity (HR-VPP): Seasonal Trajectories (PPI) and Vegetation Indices (FAPAR, LAI, NDVI, PPI, FCOVER, DMP)
     -   High Resolution Water & Snow / Ice (HR-WSI): CC, FSC, GFSC, ICD, SWS, WDS, WIC, WIC-COMB, SP_S2, SP_COMB

--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -402,7 +402,16 @@ def validate_schema(
             res = parse_auto(example)
             if not res.valid:
                 raise ValueError(f"Parsing failed for {example}")
-            fields = {k: v for k, v in res.fields.items() if v is not None}
+            fields = {
+                k: v
+                for k, v in _extract_fields(example, schema).items()
+                if v is not None
+            }
+            if not fields:
+                raise ValueError(
+                    "Example parsed globally but not by its declared schema: "
+                    f"{schema_path} -> {example}"
+                )
             assembled = assemble(fields, schema_path=schema_path)
             if assembled != example:
                 raise ValueError(f"Round trip failed for {example}")

--- a/src/parseo/schemas/copernicus/clms/egms/egms_gnss_model_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/egms/egms_gnss_model_filename_v0_0_0.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:egms-gnss-model",
+  "schema_version": "0.0.0",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "description": "Copernicus European Ground Motion Service GNSS model filename.",
+  "fields": {
+    "prefix": {
+      "type": "string",
+      "enum": ["EGMS"],
+      "description": "Constant service prefix"
+    },
+    "product": {
+      "type": "string",
+      "enum": ["AEPND"],
+      "description": "Product identifier"
+    },
+    "issue_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Year of issue"
+    },
+    "revision": {
+      "type": "string",
+      "pattern": "^\\d$",
+      "description": "Revision within the year (0 pre-release, 1 first full release)"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["csv"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{prefix}_{product}_V{issue_year}.{revision}.{extension}",
+  "examples": [
+    "EGMS_AEPND_V2020.0.csv",
+    "EGMS_AEPND_V2023.1.csv"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/egms/egms_l2a_product_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/egms/egms_l2a_product_filename_v0_0_0.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:egms-l2a",
+  "schema_version": "0.0.0",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "description": "Copernicus European Ground Motion Service Level 2 basic and calibrated product filename (extension optional).",
+  "fields": {
+    "prefix": {
+      "type": "string",
+      "enum": ["EGMS"],
+      "description": "Constant service prefix"
+    },
+    "level": {
+      "type": "string",
+      "pattern": "^L[0-9]+[a-zA-Z]$",
+      "description": "Product processing level"
+    },
+    "track": {
+      "type": "string",
+      "pattern": "^\\d{3}$",
+      "description": "Sentinel-1 track number"
+    },
+    "burst": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Progressive index of the burst inside the track"
+    },
+    "swath": {
+      "type": "string",
+      "pattern": "^IW[0-9]$",
+      "description": "Sentinel-1 IW swath identifier"
+    },
+    "polarisation": {
+      "type": "string",
+      "pattern": "^(?:VV|VH|HH|HV)$",
+      "description": "Polarisation of the SAR acquisition"
+    },
+    "start_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "First nominal year included in the product"
+    },
+    "end_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Last nominal year included in the product"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+$",
+      "description": "Version of the delivered data"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["csv", "zip"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{prefix}_{level}_{track}_{burst}_{swath}_{polarisation}_{start_year}_{end_year}_{version}[.{extension}]",
+  "examples": [
+    "EGMS_L2a_088_0282_IW2_VV_2018_2022_1.csv",
+    "EGMS_L2a_088_0282_IW2_VV_2018_2022_1.zip",
+    "EGMS_L2a_124_0135_IW1_VH_2015_2020_2.csv"
+  ]
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -262,6 +262,61 @@ def test_parse_clms_egms_l3_velocity_grid():
     }
 
 
+def test_parse_clms_egms_l2a_product_csv():
+    name = "EGMS_L2a_088_0282_IW2_VV_2018_2022_1.csv"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "EGMS-L2A"
+    assert result.fields == {
+        "prefix": "EGMS",
+        "level": "L2a",
+        "track": "088",
+        "burst": "0282",
+        "swath": "IW2",
+        "polarisation": "VV",
+        "start_year": "2018",
+        "end_year": "2022",
+        "version": "1",
+        "extension": "csv",
+    }
+
+
+def test_parse_clms_egms_l2a_product_zip():
+    name = "EGMS_L2a_124_0135_IW1_VH_2015_2020_2.zip"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "EGMS-L2A"
+    assert result.fields == {
+        "prefix": "EGMS",
+        "level": "L2a",
+        "track": "124",
+        "burst": "0135",
+        "swath": "IW1",
+        "polarisation": "VH",
+        "start_year": "2015",
+        "end_year": "2020",
+        "version": "2",
+        "extension": "zip",
+    }
+
+
+def test_parse_clms_egms_gnss_model():
+    name = "EGMS_AEPND_V2023.1.csv"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "EGMS-GNSS-MODEL"
+    assert result.fields == {
+        "prefix": "EGMS",
+        "product": "AEPND",
+        "issue_year": "2023",
+        "revision": "1",
+        "extension": "csv",
+    }
+
+
 def test_parse_modis_stac_mapping():
     name = "MOD09GA.A2021123.h18v04.006.2021132234506.hdf"
     result = parse_auto(name)


### PR DESCRIPTION
## Summary
- add schemas for EGMS Level 2 basic/calibrated products and GNSS model filenames
- extend parser validation to use schema-specific field extraction when round-tripping examples
- cover new schemas with parser tests and update README capabilities

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68e16cf5dc4c8327b48cd46201d5df3d