### PR TITLE
Normalize CLMS type field to raster/vector

### DIFF
--- a/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
@@ -20,7 +20,13 @@
     "type": {
       "type": "string",
       "enum": ["RAS"],
-      "description": "Data class code (raster)"
+      "description": "Data class code (raster)",
+      "stac_map": {
+        "preserve_original_as": "type_code",
+        "values": {
+          "RAS": {"type": "raster"}
+        }
+      }
     },
     "season": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/urban-atlas/ua_dhm_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/urban-atlas/ua_dhm_filename_v0_0_0.json
@@ -25,7 +25,13 @@
     "type": {
       "type": "string",
       "enum": ["V"],
-      "description": "Data type vector"
+      "description": "Data type vector",
+      "stac_map": {
+        "preserve_original_as": "type_code",
+        "values": {
+          "V": {"type": "vector"}
+        }
+      }
     },
     "reference_year": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/urban-atlas/ua_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/urban-atlas/ua_filename_v0_0_0.json
@@ -30,7 +30,14 @@
     "type": {
       "type": "string",
       "enum": ["V","R"],
-      "description": "Data type raster or vector"
+      "description": "Data type raster or vector",
+      "stac_map": {
+        "preserve_original_as": "type_code",
+        "values": {
+          "V": {"type": "vector"},
+          "R": {"type": "raster"}
+        }
+      }
     },
     "resolution": {
       "type": "string",

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -104,6 +104,48 @@ def test_assemble_clms_hrl_imperviousness():
     assert name == "IMD_2021_E042N018_010m_V100.tif"
 
 
+def test_assemble_clms_urban_atlas_with_canonical_type():
+    fields = {
+        "programme": "CLMS",
+        "product": "UA",
+        "variable": "LCU",
+        "survey": "S2021",
+        "type": "vector",
+        "resolution": "025ha",
+        "area_code": "DK004L3",
+        "city": "AALBORG",
+        "epsg_code": "03035",
+        "version": "V01",
+        "revision": "R00",
+        "production_date": "20240212",
+    }
+
+    name = assemble(fields, family="UA-LCU")
+    assert name == "CLMS_UA_LCU_S2021_V025ha_DK004L3_AALBORG_03035_V01_R00_20240212"
+
+
+def test_assemble_clms_clcplus_with_canonical_type():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json"
+    )
+    fields = {
+        "programme": "CLMS",
+        "product": "CLCPLUS",
+        "type": "raster",
+        "season": "S2023",
+        "resolution": "R10m",
+        "tile": "E48N37",
+        "product_code": "03035",
+        "version": "V01",
+        "revision": "R00",
+        "extension": "tif",
+    }
+
+    name = assemble(fields, schema_path=schema)
+    assert name == "CLMS_CLCPLUS_RAS_S2023_R10m_E48N37_03035_V01_R00.tif"
+
+
 def test_assemble_modis_from_stac_fields():
     schema = (
         Path(__file__).resolve().parents[1]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -170,7 +170,8 @@ def test_parse_urban_atlas_lcu():
         "product": "UA",
         "variable": "LCU",
         "survey": "S2021",
-        "type": "V",
+        "type": "vector",
+        "type_code": "V",
         "resolution": "025ha",
         "area_code": "DK004L3",
         "city": "AALBORG",
@@ -180,6 +181,16 @@ def test_parse_urban_atlas_lcu():
         "production_date": "20240212",
         "extension": None,
     }
+
+
+def test_parse_clms_clcplus_type_mapping():
+    name = "CLMS_CLCPLUS_RAS_S2023_R10m_E48N37_03035_V01_R00.tif"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "RAS"
+    assert result.fields["type"] == "raster"
+    assert result.fields["type_code"] == "RAS"
 
 
 


### PR DESCRIPTION
## Summary
- map CLMS schema type tokens to canonical raster/vector values via stac_map definitions
- preserve original CLMS type codes while exposing normalized values to clients
- cover the new behaviour with parser and assembler regression tests

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e221e4a9f4832798aff875a2e20ff6