### PR TITLE
Fix CLCPLUS schema metadata

### DIFF
--- a/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "schema_id": "copernicus:clms:clcplus:ras",
+  "schema_id": "copernicus:clms:clcplus",
   "schema_version": "0.0.1",
   "status": "current",
   "stac_version": "1.1.0",
@@ -42,9 +42,9 @@
       "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
       "description": "Tile identifier in the EEA 10m grid (easting/northing)"
     },
-    "product_code": {
+    "epsg_code": {
       "type": "string",
-      "pattern": "^\\d{5}$",
+      "pattern": "^0?\\d{4}$",
       "description": "EPSG code of the product grid"
     },
     "version": {
@@ -63,7 +63,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{product}_{type}_{season}_{resolution}_{tile}_{product_code}_{version}_{revision}[.{extension}]",
+  "template": "{programme}_{product}_{type}_{season}_{resolution}_{tile}_{epsg_code}_{version}_{revision}[.{extension}]",
   "examples": [
     "CLMS_CLCPLUS_RAS_S2023_R10m_E48N37_03035_V01_R00.tif"
   ]

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -136,7 +136,7 @@ def test_assemble_clms_clcplus_with_canonical_type():
         "season": "S2023",
         "resolution": "R10m",
         "tile": "E48N37",
-        "product_code": "03035",
+        "epsg_code": "03035",
         "version": "V01",
         "revision": "R00",
         "extension": "tif",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -188,8 +188,9 @@ def test_parse_clms_clcplus_type_mapping():
     result = parse_auto(name)
 
     assert result.valid
-    assert result.match_family == "RAS"
+    assert result.match_family == "CLCPLUS"
     assert result.fields["type"] == "raster"
+    assert result.fields["epsg_code"] == "03035"
     assert "type_code" not in result.fields
 
 


### PR DESCRIPTION
## Summary
- update the CLMS CLCPLUS schema to report the clcplus family and expose the EPSG code field
- adjust assembler and parser tests for the renamed epsg_code field and updated match family

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e25785e4ec8327846dcae6cb8f1a4b