### PR TITLE
Add CLI command to list CLMS catalog products

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ parseo parse S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE
 
 # Assemble using a JSON document with the required fields
 parseo assemble --family S2 fields.json
+
+# Review Copernicus Land Monitoring Service datasets from the public catalog
+parseo clms-products --catalog-url https://land.copernicus.eu/en/dataset-catalog
 ```
 
 ### Working with specific schema versions

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -11,6 +11,7 @@ from typing import Union
 
 from parseo import __version__
 from parseo.assembler import assemble_auto
+from parseo.clms_catalog import fetch_clms_products
 from parseo.parser import describe_schema  # parser helpers
 from parseo.parser import parse_auto
 from parseo.schema_registry import list_schema_families
@@ -37,6 +38,19 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
     # list-schemas
     sp.add_parser("list-schemas", help="List available schema families")
+
+    # clms-products
+    p_clms = sp.add_parser(
+        "clms-products",
+        help="List dataset titles from the Copernicus Land Monitoring Service catalog",
+    )
+    p_clms.add_argument(
+        "--catalog-url",
+        help=(
+            "Override the catalog URL. When omitted, the CLMS_DATASET_CATALOG_URL "
+            "environment variable is used."
+        ),
+    )
 
     # schema-info
     p_info = sp.add_parser("schema-info", help="Show details for a mission family")
@@ -218,6 +232,15 @@ def main(argv: Union[List[str], None] = None) -> int:
         except KeyError as e:
             raise SystemExit(str(e))
         print(json.dumps(info, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.cmd == "clms-products":
+        try:
+            products = fetch_clms_products(url=args.catalog_url)
+        except ValueError as exc:
+            raise SystemExit(str(exc))
+        for title in products:
+            print(title)
         return 0
 
     if args.cmd == "list-stac-collections":

--- a/tests/test_clms_catalog.py
+++ b/tests/test_clms_catalog.py
@@ -1,3 +1,6 @@
+import pytest
+
+from parseo import cli
 from parseo.clms_catalog import parse_html
 
 
@@ -10,3 +13,41 @@ def test_parse_html_extracts_titles():
     </body></html>
     """
     assert parse_html(html) == ["Product A", "Product B"]
+
+
+def test_cli_clms_products_reads_env(monkeypatch, capsys):
+    monkeypatch.setenv("CLMS_DATASET_CATALOG_URL", "https://example.test/catalog")
+
+    def fake_fetch(url=None):  # type: ignore[override]
+        assert url is None
+        return ["Dataset One", "Dataset Two"]
+
+    monkeypatch.setattr("parseo.cli.fetch_clms_products", fake_fetch)
+    rc = cli.main(["clms-products"])
+    assert rc == 0
+    out = capsys.readouterr().out.splitlines()
+    assert out == ["Dataset One", "Dataset Two"]
+
+
+def test_cli_clms_products_accepts_custom_url(monkeypatch, capsys):
+    seen = {}
+
+    def fake_fetch(url=None):  # type: ignore[override]
+        seen["url"] = url
+        return []
+
+    monkeypatch.setattr("parseo.cli.fetch_clms_products", fake_fetch)
+    rc = cli.main(["clms-products", "--catalog-url", "https://custom.example"])
+    assert rc == 0
+    assert seen["url"] == "https://custom.example"
+    assert capsys.readouterr().out == ""
+
+
+def test_cli_clms_products_reports_missing_url(monkeypatch):
+    def fake_fetch(url=None):  # type: ignore[override]
+        raise ValueError("Catalog URL not provided")
+
+    monkeypatch.setattr("parseo.cli.fetch_clms_products", fake_fetch)
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["clms-products"])
+    assert "Catalog URL not provided" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add a `clms-products` CLI subcommand that lists dataset titles from the Copernicus Land Monitoring Service catalog
- document the new command in the README for quick discovery
- exercise the command with unit tests covering environment, custom URL, and error flows

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e25d45d76083278603b132cb77356c