### PR TITLE
Add CLI alias for CLMS product listing command

### DIFF
--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -43,6 +43,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p_clms = sp.add_parser(
         "clms-products",
         help="List dataset titles from the Copernicus Land Monitoring Service catalog",
+        aliases=["clms"],
     )
     p_clms.add_argument(
         "--catalog-url",
@@ -234,7 +235,7 @@ def main(argv: Union[List[str], None] = None) -> int:
         print(json.dumps(info, indent=2, ensure_ascii=False))
         return 0
 
-    if args.cmd == "clms-products":
+    if args.cmd in {"clms-products", "clms"}:
         try:
             products = fetch_clms_products(url=args.catalog_url)
         except ValueError as exc:

--- a/tests/test_clms_catalog.py
+++ b/tests/test_clms_catalog.py
@@ -29,6 +29,19 @@ def test_cli_clms_products_reads_env(monkeypatch, capsys):
     assert out == ["Dataset One", "Dataset Two"]
 
 
+def test_cli_clms_alias(monkeypatch, capsys):
+    monkeypatch.setenv("CLMS_DATASET_CATALOG_URL", "https://example.test/catalog")
+
+    def fake_fetch(url=None):  # type: ignore[override]
+        assert url is None
+        return ["Dataset One"]
+
+    monkeypatch.setattr("parseo.cli.fetch_clms_products", fake_fetch)
+    rc = cli.main(["clms"])
+    assert rc == 0
+    assert capsys.readouterr().out.splitlines() == ["Dataset One"]
+
+
 def test_cli_clms_products_accepts_custom_url(monkeypatch, capsys):
     seen = {}
 


### PR DESCRIPTION
## Summary
- add a short `clms` alias for the `clms-products` CLI subcommand
- cover the new alias with a dedicated test

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e26091e5188327b77ca2fc8b0198ca