### PR TITLE
Rename CLMS schema EEA tiles to eea_tile

### DIFF
--- a/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
@@ -37,7 +37,7 @@
       "pattern": "^R\\d{2}m$",
       "description": "Spatial resolution expressed with leading 'R' and units"
     },
-    "tile": {
+    "eea_tile": {
       "type": "string",
       "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
       "description": "Tile identifier in the EEA 10m grid (easting/northing)"
@@ -63,7 +63,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{product}_{type}_{season}_{resolution}_{tile}_{epsg_code}_{version}_{revision}[.{extension}]",
+  "template": "{programme}_{product}_{type}_{season}_{resolution}_{eea_tile}_{epsg_code}_{version}_{revision}[.{extension}]",
   "examples": [
     "CLMS_CLCPLUS_RAS_S2023_R10m_E48N37_03035_V01_R00.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
@@ -10,12 +10,12 @@
     "variable": {"type": "string", "enum": ["IBU"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
     "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution in metres with leading zeros"},
-    "tile": {"type": "string", "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$", "description": "EEA reference grid tile identifier"},
+    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$", "description": "EEA reference grid tile identifier"},
     "epsg_code": {"type": "string", "pattern": "^\\d{5}$", "description": "EPSG code of the product grid"},
     "version": {"type": "string", "pattern": "^v\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{resolution}_{tile}_{epsg_code}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{resolution}_{eea_tile}_{epsg_code}_{version}[.{extension}]",
   "examples": [
     "IBU_2018_010m_E47N18_03035_v010.tif",
     "IBU_2018_010m_E47N19_03035_v010.tif",

--- a/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
@@ -32,7 +32,7 @@
       "pattern": "^R\\d{2,3}m$",
       "description": "Spatial resolution"
     },
-    "tile": {
+    "eea_tile": {
       "type": "string",
       "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
       "description": "Tile identifier in the EEA 10m grid (easting/northing)"
@@ -58,7 +58,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{prefix}_{theme}_{variable}_{temporal_coverage}_{resolution}_{tile}_{epsg_code}_{version}_{release}[.{extension}]",
+  "template": "{prefix}_{theme}_{variable}_{temporal_coverage}_{resolution}_{eea_tile}_{epsg_code}_{version}_{release}[.{extension}]",
   "examples": [
     "CLMS_HRLNVLCC_IMCCS_C2018-2021_R20m_E09N27_03035_V01_R01.tif",
     "CLMS_HRLNVLCC_IMD_S2021_R10m_E09N27_03035_V01_R01.tif",

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
@@ -22,7 +22,7 @@
       "pattern": "^(?:005m|010m|020m|100m)$",
       "description": "Spatial resolution"
     },
-    "tile": {
+    "eea_tile": {
       "type": "string",
       "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
       "description": "EEA reference grid tile identifier"
@@ -38,7 +38,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{variable}_{reference_year}_{resolution}_{tile}_{epsg_code}[.{extension}]",
+  "template": "{variable}_{reference_year}_{resolution}_{eea_tile}_{epsg_code}[.{extension}]",
   "examples": [
     "SWF_2018_005m_E34N27_03035.tif",
     "SWF_2018_005m_E36N31_03035.tif"

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -135,7 +135,7 @@ def test_assemble_clms_clcplus_with_canonical_type():
         "type": "raster",
         "season": "S2023",
         "resolution": "R10m",
-        "tile": "E48N37",
+        "eea_tile": "E48N37",
         "epsg_code": "03035",
         "version": "V01",
         "revision": "R00",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -207,7 +207,7 @@ def test_parse_clms_hrl_nvlcc():
         "variable": "IMD",
         "temporal_coverage": "S2021",
         "resolution": "R10m",
-        "tile": "E09N27",
+        "eea_tile": "E09N27",
         "epsg_code": "03035",
         "version": "V01",
         "release": "R01",
@@ -234,7 +234,7 @@ def test_parse_clms_hrl_small_woody_features():
         "variable": "SWF",
         "reference_year": "2018",
         "resolution": "005m",
-        "tile": "E34N27",
+        "eea_tile": "E34N27",
         "epsg_code": "03035",
         "extension": "tif",
     }


### PR DESCRIPTION
## Summary
- rename the EEA grid tile token to `eea_tile` in CLMS schemas that use EPSG:3035
- adjust parser and assembler tests to the new field name

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e27a97f36c8327ace52815d676d3f3