### PR TITLE
Broaden HR-VPP tile schemas for 3-digit EEA coordinates

### DIFF
--- a/src/parseo/_tile_systems.py
+++ b/src/parseo/_tile_systems.py
@@ -1,0 +1,44 @@
+"""Helpers for recognizing spatial tile identifier systems."""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Optional
+
+
+class TileSystem(str, Enum):
+    """Known spatial tiling systems."""
+
+    MGRS = "mgrs"
+    EEA = "eea"
+
+
+_MGRS_PATTERN = re.compile(r"^T\d{2}[C-HJ-NP-X][A-Z]{2}$")
+_EEA_PATTERN = re.compile(r"^[EW]\d{2,3}[NS]\d{2,3}$")
+
+
+def detect_tile_system(tile: str) -> Optional[TileSystem]:
+    """Return the :class:`TileSystem` matching *tile*, if any."""
+
+    if not isinstance(tile, str):
+        return None
+
+    candidate = tile.strip().upper()
+    if not candidate:
+        return None
+
+    if _MGRS_PATTERN.fullmatch(candidate):
+        return TileSystem.MGRS
+
+    if _EEA_PATTERN.fullmatch(candidate):
+        return TileSystem.EEA
+
+    return None
+
+
+def normalize_tile(tile: str) -> str:
+    """Return a normalised representation of *tile*."""
+
+    return tile.strip().upper()
+

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
@@ -12,8 +12,8 @@
     "sensor": {"type": "string", "enum": ["S2"], "description": "Sensor platform"},
     "eea_tile": {
       "type": "string",
-      "pattern": "^([EW]\\d{2}[NS]\\d{2}|T\\d{2}[A-Z]{3})$",
-      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier"
+      "pattern": "^([EW]\\d{2,3}[NS]\\d{2,3}|T\\d{2}[C-HJ-NP-X][A-Z]{2})$",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)"
     },
     "epsg_code": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
@@ -34,9 +34,9 @@
     },
     "tile": {
       "type": "string",
-      "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|[EW]\\d{2}[NS]\\d{2})$",
-      "description": "Sentinel-2 MGRS tile or EEA LAEA reference grid cell identifier"
-    },    
+      "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|[EW]\\d{2,3}[NS]\\d{2,3})$",
+      "description": "Sentinel-2 MGRS tile or EEA LAEA reference grid cell identifier (2- or 3-digit coordinates)"
+    },
     "epsg_code": {
       "type": "string",
       "pattern": "^\\d{4,5}$",

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -188,3 +188,43 @@ def test_assemble_landsat_from_stac_fields():
     assembled = assemble(fields, schema_path=schema)
     assert assembled == "LC08_L1TP_190026_20200101_20200114_02_T1.tar"
 
+
+
+
+def test_assemble_clms_hr_vpp_from_mgrs_tile():
+    fields = {
+        "product": "VPP",
+        "reference_year": "2017",
+        "platform": "Sentinel-2",
+        "constellation": "Sentinel-2",
+        "instruments": ["MSI"],
+        "mgrs_tile": "T32TPR",
+        "resolution": "010m",
+        "version": "V101",
+        "season": "s1",
+        "variable": "AMPL",
+        "extension": "tif",
+    }
+
+    name = assemble(fields, family="VPP")
+    assert name == "VPP_2017_S2_T32TPR-010m_V101_s1_AMPL.tif"
+
+
+def test_assemble_clms_hr_vpp_from_eea_tile():
+    fields = {
+        "product": "VPP",
+        "reference_year": "2017",
+        "platform": "Sentinel-2",
+        "constellation": "Sentinel-2",
+        "instruments": ["MSI"],
+        "eea_tile": "E042N018",
+        "epsg_code": "03035",
+        "resolution": "010m",
+        "version": "V101",
+        "season": "s1",
+        "variable": "EOSD",
+        "extension": "tif",
+    }
+
+    name = assemble(fields, family="VPP")
+    assert name == "VPP_2017_S2_E042N018-03035-010m_V101_s1_EOSD.tif"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -353,3 +353,28 @@ def test_parse_sentinel2_epsg_lookup():
     assert result.match_family == "S2"
     assert result.fields["mgrs_tile"] == "T03VUL"
     assert result.fields["epsg_code"] == "32603"
+
+
+
+
+def test_parse_clms_hr_vpp_mgrs_tile():
+    name = "VPP_2017_S2_T32TPR-010m_V101_s1_AMPL.tif"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "VPP"
+    assert result.fields["tile"] == "T32TPR"
+    assert result.fields["mgrs_tile"] == "T32TPR"
+    assert "eea_tile" not in result.fields
+
+
+def test_parse_clms_hr_vpp_eea_tile():
+    name = "VPP_2017_S2_E042N018-03035-010m_V101_s1_EOSD.tif"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "VPP"
+    assert result.fields["tile"] == "E042N018"
+    assert result.fields["eea_tile"] == "E042N018"
+    assert result.fields["epsg_code"] == "03035"
+    assert "mgrs_tile" not in result.fields


### PR DESCRIPTION
## Summary
- update HR-VPP filename schemas to accept EEA tile identifiers with two or three digits per axis and tighten the MGRS pattern
- refresh assembler and parser regression tests to cover EEA tiles with three-digit coordinates

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2985d47ec832785c252c26e656da7